### PR TITLE
remove sigterm handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed a bug with `FromParams` that caused `.from_params()` to fail when the params contained
   an object that was already instantiated.
+- tango command no longer installs a SIGTERM handler, which fixes some bugs with integrations that use multiprocessing.
 
 ## [v0.3.1](https://github.com/allenai/tango/releases/tag/v0.3.1) - 2021-10-29
 

--- a/tango/__main__.py
+++ b/tango/__main__.py
@@ -72,7 +72,6 @@ import tango.common.logging as common_logging
 from tango.common.aliases import PathOrStr
 from tango.common.from_params import FromParams
 from tango.common.params import Params
-from tango.common.util import install_sigterm_handler
 from tango.version import VERSION
 
 
@@ -182,9 +181,6 @@ def main(
     common_logging.initialize_logging(
         log_level=log_level, file_friendly_logging=file_friendly_logging
     )
-
-    # We want to be able to catch SIGTERM signals in addition to SIGINT (keyboard interrupt).
-    install_sigterm_handler()
 
     ctx.obj = config
 


### PR DESCRIPTION
The `SIGTERM` handler we install seems to cause more problems that it solves.