### PR TITLE
fix bug with git metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Fixed small bug where some errors from git would be printed when executor metadata is created
+  outside of a git repository.
+
 ## [v0.3.2](https://github.com/allenai/tango/releases/tag/v0.3.2) - 2021-11-01
 
 ### Fixed

--- a/tango/executor.py
+++ b/tango/executor.py
@@ -321,7 +321,9 @@ class GitMetadata(FromParams):
 
         try:
             commit = (
-                subprocess.check_output("git rev-parse HEAD".split(" ")).decode("ascii").strip()
+                subprocess.check_output("git rev-parse HEAD".split(" "), stderr=subprocess.DEVNULL)
+                .decode("ascii")
+                .strip()
             )
             remote: Optional[str] = None
             for line in (

--- a/tests/executor_test.py
+++ b/tests/executor_test.py
@@ -9,6 +9,7 @@ class TestMetadata(TangoTestCase):
         metadata.save(self.TEST_DIR)
 
         assert metadata.git is not None
+        assert metadata.git.commit is not None
         assert metadata.git.remote is not None
         assert "allenai/tango" in metadata.git.remote
 


### PR DESCRIPTION
Fixes a small bug where some errors from git would be printed when executor metadata is created outside of a git repository.