### PR TITLE
fix another FromParams bug, add spot for miscellaneous end-to-end tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ on:
 
 env:
   # Change this to invalidate existing cache.
-  CACHE_PREFIX: v2
+  CACHE_PREFIX: v3
   PYTHON_PATH: ./
   DEFAULT_PYTHON: 3.7
 
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: [3.7]
+        python: ['3.7']
         task:
           - name: Lint
             extras: dev,all
@@ -91,21 +91,21 @@ jobs:
               extras: dev
               run: |
                 pytest -v --color=yes --doctest-modules --ignore=tests/integrations --ignore=tango/integrations tests/ tango/
-            python: 3.8
+            python: '3.8'
 
           - task:
               name: Test
               extras: dev
               run: |
                 pytest -v --color=yes --doctest-modules --ignore=tests/integrations --ignore=tango/integrations tests/ tango/
-            python: 3.9
+            python: '3.9'
 
           - task:
               name: Test
               extras: dev
               run: |
                 pytest -v --color=yes --doctest-modules --ignore=tests/integrations --ignore=tango/integrations tests/ tango/
-            python: 3.10
+            python: '3.10'
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ on:
 
 env:
   # Change this to invalidate existing cache.
-  CACHE_PREFIX: v1
+  CACHE_PREFIX: v2
   PYTHON_PATH: ./
   DEFAULT_PYTHON: 3.7
 
@@ -84,6 +84,11 @@ jobs:
               cd examples/train_gpt2
               pytest -v --color=yes test.py
 
+        include:
+          - task:
+              name: Test
+            python: 3.8
+
     steps:
       - uses: actions/checkout@v2
 
@@ -112,8 +117,6 @@ jobs:
         with:
           path: .venv
           key: ${{ env.CACHE_PREFIX }}-${{ env.WEEK_NUMBER }}-${{ runner.os }}-${{ env.RUNNER_ARCH }}-${{ env.PYTHON_VERSION }}-${{ env.EXTRAS_HASH }}-${{ hashFiles('*requirements.txt') }}
-          restore-keys: |
-            ${{ env.CACHE_PREFIX }}-${{ env.WEEK_NUMBER }}-${{ runner.os }}-${{ env.RUNNER_ARCH }}-${{ env.PYTHON_VERSION }}-${{ env.EXTRAS_HASH }}-
 
       - name: Setup virtual environment (no cache hit)
         if: steps.virtualenv-cache.outputs.cache-hit != 'true'
@@ -124,7 +127,7 @@ jobs:
         if: steps.virtualenv-cache.outputs.cache-hit != 'true' && contains(matrix.task.extras, 'torch')
         run: |
           . .venv/bin/activate
-          pip install torch==1.9.1+cpu -f https://download.pytorch.org/whl/torch_stable.html
+          pip install torch==1.10.0+cpu -f https://download.pytorch.org/whl/cpu/torch_stable.html
 
       - name: Install editable (no cache hit)
         if: steps.virtualenv-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,12 +85,27 @@ jobs:
               pytest -v --color=yes test.py
 
         include:
+          # Run the core tests on other Python versions as well.
           - task:
               name: Test
               extras: dev
               run: |
                 pytest -v --color=yes --doctest-modules --ignore=tests/integrations --ignore=tango/integrations tests/ tango/
             python: 3.8
+
+          - task:
+              name: Test
+              extras: dev
+              run: |
+                pytest -v --color=yes --doctest-modules --ignore=tests/integrations --ignore=tango/integrations tests/ tango/
+            python: 3.9
+
+          - task:
+              name: Test
+              extras: dev
+              run: |
+                pytest -v --color=yes --doctest-modules --ignore=tests/integrations --ignore=tango/integrations tests/ tango/
+            python: 3.10
 
     steps:
       - uses: actions/checkout@v2
@@ -127,7 +142,7 @@ jobs:
           test -d .venv || virtualenv -p $(which python) --copies --reset-app-data .venv
 
       - name: Pre-install torch
-        if: steps.virtualenv-cache.outputs.cache-hit != 'true' && contains(matrix.task.extras, 'torch')
+        if: steps.virtualenv-cache.outputs.cache-hit != 'true' && (contains(matrix.task.extras, 'torch') || contains(matrix.task.extras, 'all'))
         run: |
           . .venv/bin/activate
           pip install torch==1.10.0+cpu -f https://download.pytorch.org/whl/cpu/torch_stable.html

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,9 @@ jobs:
         include:
           - task:
               name: Test
+              extras: dev
+              run: |
+                pytest -v --color=yes --doctest-modules --ignore=tests/integrations --ignore=tango/integrations tests/ tango/
             python: 3.8
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- [internals] Added a spot for miscellaneous end-to-end integration tests (not to be confused with "tests of integrations") in `tests/end_to_end/`.
+
+### Fixed
+
+- Fixed a bug in `FromParams` where non-`FromParams` class parameters were not instantiated
+  properly (or at all).
+
 ## [v0.3.2](https://github.com/allenai/tango/releases/tag/v0.3.2) - 2021-11-01
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - [internals] Added a spot for miscellaneous end-to-end integration tests (not to be confused with "tests of integrations") in `tests/end_to_end/`.
+- [internals] Core tests now run on all officially supported Python versions.
 
 ### Fixed
 

--- a/tango/common/from_params.py
+++ b/tango/common/from_params.py
@@ -321,11 +321,9 @@ def construct_arg(
     if inspect.isclass(annotation) and issubclass(annotation, FromParams):
         if popped_params is default:
             return default
-        elif isinstance(popped_params, annotation):
+        elif origin is None and isinstance(popped_params, annotation):
             return popped_params
         elif popped_params is not None:
-            # Our params have an entry for this, so we use that.
-
             subextras = create_extras(annotation, extras)
 
             # In some cases we allow a string instead of a param dict, so
@@ -526,6 +524,13 @@ def construct_arg(
             value_list.append(value)
 
         return value_list
+
+    elif inspect.isclass(annotation) and isinstance(popped_params, Params):
+        subextras = create_extras(annotation, extras)
+        constructor_to_inspect = annotation.__init__
+        constructor_to_call = annotation
+        kwargs = create_kwargs(constructor_to_inspect, annotation, popped_params, **subextras)
+        return constructor_to_call(**kwargs)  # type: ignore
 
     else:
         # Pass it on as is and hope for the best.   ¯\_(ツ)_/¯

--- a/tests/end_to_end/test_dataset_dict_from_seperate_steps.py
+++ b/tests/end_to_end/test_dataset_dict_from_seperate_steps.py
@@ -1,0 +1,58 @@
+from typing import Any, Dict, Sequence
+
+from tango import JsonFormat, Step
+from tango.common import DatasetDict
+from tango.common.testing import run_experiment
+
+
+@Step.register("train_data")
+class TrainData(Step):
+    DETERMINISTIC = True
+    CACHEABLE = False
+
+    def run(self) -> Sequence[int]:
+        return list(range(10))
+
+
+@Step.register("val_data")
+class ValData(Step):
+    DETERMINISTIC = True
+    CACHEABLE = False
+
+    def run(self) -> Sequence[int]:
+        return list(range(10, 20))
+
+
+@Step.register("save_data")
+class SaveData(Step):
+    DETERMINISTIC = True
+    CACHEABLE = True
+    FORMAT = JsonFormat()
+
+    def run(self, dataset_dict: DatasetDict) -> Dict[str, Any]:
+        return dataset_dict.splits
+
+
+def test_experiment():
+    with run_experiment(
+        {
+            "steps": {
+                "train_data": {
+                    "type": "train_data",
+                },
+                "val_data": {
+                    "type": "val_data",
+                },
+                "saved_data": {
+                    "type": "save_data",
+                    "dataset_dict": {
+                        "splits": {
+                            "train": {"type": "ref", "ref": "train_data"},
+                            "val": {"type": "ref", "ref": "val_data"},
+                        }
+                    },
+                },
+            }
+        }
+    ) as run_dir:
+        assert (run_dir / "saved_data").is_dir()

--- a/tests/end_to_end/test_dataset_dict_from_seperate_steps.py
+++ b/tests/end_to_end/test_dataset_dict_from_seperate_steps.py
@@ -1,6 +1,6 @@
-from typing import Any, Dict, Sequence
+from typing import Any, Sequence
 
-from tango import JsonFormat, Step
+from tango import Format, JsonFormat, Step
 from tango.common import DatasetDict
 from tango.common.testing import run_experiment
 
@@ -10,7 +10,7 @@ class TrainData(Step):
     DETERMINISTIC = True
     CACHEABLE = False
 
-    def run(self) -> Sequence[int]:
+    def run(self) -> Sequence[int]:  # type: ignore
         return list(range(10))
 
 
@@ -19,7 +19,7 @@ class ValData(Step):
     DETERMINISTIC = True
     CACHEABLE = False
 
-    def run(self) -> Sequence[int]:
+    def run(self) -> Sequence[int]:  # type: ignore
         return list(range(10, 20))
 
 
@@ -27,9 +27,9 @@ class ValData(Step):
 class SaveData(Step):
     DETERMINISTIC = True
     CACHEABLE = True
-    FORMAT = JsonFormat()
+    FORMAT: Format = JsonFormat()
 
-    def run(self, dataset_dict: DatasetDict) -> Dict[str, Any]:
+    def run(self, dataset_dict: DatasetDict) -> Any:  # type: ignore
         return dataset_dict.splits
 
 


### PR DESCRIPTION
- Adds a spot for miscellaneous end-to-end integration tests (not to be confused with "tests of integrations") in `tests/end_to_end/`.
- Fixes a bug in `FromParams` where non-`FromParams` class parameters were not instantiated
  properly (or at all). The test I added will fail without this fix.