### PR TITLE
PEP 604 support

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,7 @@
 <!-- To ensure we can review your pull request promptly please complete this template entirely. -->
 
 <!-- Please reference the issue number here. You can replace "Fixes" with "Closes" if it makes more sense. -->
-Fixes # .
+Fixes #
 
 Changes proposed in this pull request:
 <!-- Please list all changes/additions here. -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added support for PEP 604 in `FromParams`, i.e. writing union types as "X | Y" instead of "Union[X, Y]".
 - [internals] Added a spot for miscellaneous end-to-end integration tests (not to be confused with "tests of integrations") in `tests/end_to_end/`.
 - [internals] Core tests now run on all officially supported Python versions.
 

--- a/tango/common/from_params.py
+++ b/tango/common/from_params.py
@@ -24,7 +24,7 @@ try:
     from types import UnionType  # type: ignore[attr-defined]
 except ImportError:
 
-    class UnionType:
+    class UnionType:  # type: ignore
         pass
 
 

--- a/tango/common/from_params.py
+++ b/tango/common/from_params.py
@@ -19,6 +19,15 @@ from typing import (
     cast,
 )
 
+try:
+    # For PEP 604 support (python >= 3.10)
+    from types import UnionType  # type: ignore[attr-defined]
+except ImportError:
+
+    class UnionType:
+        pass
+
+
 from ._det_hash import CustomDetHash
 from .exceptions import ConfigurationError
 from .lazy import Lazy
@@ -462,7 +471,7 @@ def construct_arg(
 
         return value_set
 
-    elif origin == Union:
+    elif origin == Union or isinstance(annotation, UnionType):
         # Storing this so we can recover it later if we need to.
         backup_params = deepcopy(popped_params)
 

--- a/tests/common/from_params_test.py
+++ b/tests/common/from_params_test.py
@@ -960,7 +960,7 @@ class TestFromParams(TangoTestCase):
         with pytest.raises(NotImplementedError):
             foo.to_params()
 
-    @pytest.mark.skipif(sys.version_info < (3, 9), reason="requires python3.9 or higher")
+    @pytest.mark.skipif(sys.version_info < (3, 9), reason="requires python 3.9 or higher")
     def test_type_hinting_generics_from_std_collections(self):
         class Item(FromParams):
             def __init__(self, a: int) -> None:
@@ -975,6 +975,19 @@ class TestFromParams(TangoTestCase):
         assert isinstance(o.x, list)
         assert isinstance(o.x[0], Item)
         assert isinstance(o.y["b"], Item)
+
+    @pytest.mark.skipif(sys.version_info < (3, 10), reason="requires python 3.10 or higher")
+    def test_with_union_pipe(self):
+        class Item(FromParams):
+            def __init__(self, a: int) -> None:
+                self.a = a
+
+        class ClassWithUnionType(FromParams):
+            def __init__(self, x: Item | str):
+                self.x = x
+
+        o = ClassWithUnionType.from_params({"x": {"a": 1}})
+        assert isinstance(o.x, Item)
 
 
 class MyClass(FromParams):


### PR DESCRIPTION
<!-- To ensure we can review your pull request promptly please complete this template entirely. -->

<!-- Please reference the issue number here. You can replace "Fixes" with "Closes" if it makes more sense. -->
Fixes #57

Changes proposed in this pull request:
<!-- Please list all changes/additions here. -->
- Adds support for typing union types like "X | Y" with Python 3.10+. See https://www.python.org/dev/peps/pep-0604/.

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [ ] I've read and followed all steps in the [Making a pull request](https://github.com/allenai/tango/blob/main/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [ ] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/allenai/tango/blob/main/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.

## After submitting

<!-- Please complete this checklist AFTER submitting your PR to speed along the review process. -->
- [ ] All GitHub Actions jobs for my pull request have passed.
