### PR TITLE
Disabled Python 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ env:
   # Change this to invalidate existing cache.
   CACHE_PREFIX: v3
   PYTHON_PATH: ./
-  DEFAULT_PYTHON: 3.7
+  DEFAULT_PYTHON: 3.8
 
 jobs:
   checks:
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.7']
+        python: ['3.8']
         task:
           - name: Lint
             extras: dev,all
@@ -86,13 +86,6 @@ jobs:
 
         include:
           # Run the core tests on other Python versions as well.
-          - task:
-              name: Test
-              extras: dev
-              run: |
-                pytest -v --color=yes --doctest-modules --ignore=tests/integrations --ignore=tango/integrations tests/ tango/
-            python: '3.8'
-
           - task:
               name: Test
               extras: dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- We no longer support Python 3.7
+- We no longer support Python 3.7.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Removed
+
+- We no longer support Python 3.7
+
 ### Added
 
 - Added a `.log_batch()` method on `torch::TrainCallback` which is given the average loss across

--- a/tango/common/_det_hash.py
+++ b/tango/common/_det_hash.py
@@ -65,7 +65,7 @@ class DetHashWithVersion(CustomDetHash):
 
 class _DetHashPickler(dill.Pickler):
     def __init__(self, buffer: io.BytesIO):
-        super().__init__(buffer)
+        super().__init__(buffer, protocol=5)
 
         # We keep track of how deeply we are nesting the pickling of an object.
         # If a class returns `self` as part of `det_hash_object()`, it causes an


### PR DESCRIPTION
This turns off Python 3.7 and makes us incompatible with it.

This change will change all step ids, so if you have an existing cache, it will be invalidated.