### PR TITLE
W&B log as step+1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- W&B `torch::TrainCallback` logs with `step=step+1` now so that training curves in the W&B dashboard
+  match up with checkpoints saved locally and are easier to read (e.g. step 10000 instead of 9999).
+
 ## [v0.3.6](https://github.com/allenai/tango/releases/tag/v0.3.6) - 2021-11-12
 
 ### Added
 
 - Added a `.log_batch()` method on `torch::TrainCallback` which is given the average loss across
   distributed workers, but only called every `log_every` steps.
-
-### Changed
-
-- W&B `torch::TrainCallback` logs with `step=step+1` now so that training curves in the W&B dashboard
-  match up with checkpoints saved locally and are easier to read (e.g. step 10000 instead of 9999).
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a `.log_batch()` method on `torch::TrainCallback` which is given the average loss across
   distributed workers, but only called every `log_every` steps.
 
+### Changed
+
+- W&B `torch::TrainCallback` logs with `step=step+1` now so that training curves in the W&B dashboard
+  match up with checkpoints saved locally and are easier to read (e.g. step 10000 instead of 9999).
+
 ### Removed
 
 - Removed `.pre_log_batch()` method on `torch::TrainCallback`.

--- a/tango/integrations/wandb/torch_train_callback.py
+++ b/tango/integrations/wandb/torch_train_callback.py
@@ -127,7 +127,7 @@ class WandbTrainCallback(TrainCallback):
         if self.is_local_main_process:
             self.wandb.log(
                 {"train/loss": batch_loss, "train/lr": self.optimizer.param_groups[0]["lr"]},
-                step=step,
+                step=step + 1,
             )
 
     @overrides
@@ -138,5 +138,5 @@ class WandbTrainCallback(TrainCallback):
                     f"val/{self.train_config.val_metric_name}": val_metric,
                     f"val/best_{self.train_config.val_metric_name}": best_val_metric,
                 },
-                step=step,
+                step=step + 1,
             )


### PR DESCRIPTION
Changes proposed in this pull request:
<!-- Please list all changes/additions here. -->
- W&B `torch::TrainCallback` logs with `step=step+1` now so that training curves in the W&B dashboard
  match up with checkpoints saved locally and are easier to read (e.g. step 10000 instead of 9999).

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [ ] I've read and followed all steps in the [Making a pull request](https://github.com/allenai/tango/blob/main/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [ ] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/allenai/tango/blob/main/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.

## After submitting

<!-- Please complete this checklist AFTER submitting your PR to speed along the review process. -->
- [ ] All GitHub Actions jobs for my pull request have passed.
