### PR TITLE
fix bug with resolving lazy step inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `Workspace`, `MemoryWorkspace`, and `LocalWorkspace` can now be imported directly from the `tango`
   base module.
+- Fixed a bug where `Lazy` inputs to a `Step` would fail to resolve arguments that come from the result
+  of another step.
 - Fixed a bug in `TorchTrainStep` where some arguments for distributed training (`devices`, `distributed_port`) weren't being set properly.
 
 ## [v0.4.0rc1](https://github.com/allenai/tango/releases/tag/v0.4.0rc1) - 2021-11-30

--- a/tango/step.py
+++ b/tango/step.py
@@ -41,6 +41,7 @@ from tango.common.from_params import (
     infer_method_params,
     pop_and_construct_arg,
 )
+from tango.common.lazy import Lazy
 from tango.common.logging import TangoLogger, click_logger
 from tango.common.params import Params
 from tango.common.registrable import Registrable
@@ -392,6 +393,16 @@ class Step(Registrable, Generic[T]):
     def _replace_steps_with_results(self, o: Any, workspace: "Workspace"):
         if isinstance(o, Step):
             return o.result(workspace, self)
+        elif isinstance(o, Lazy):
+            return Lazy(
+                o._constructor,
+                params=Params(
+                    self._replace_steps_with_results(o._params.as_dict(quiet=True), workspace)
+                ),
+                constructor_extras=self._replace_steps_with_results(
+                    o._constructor_extras, workspace
+                ),
+            )
         elif isinstance(o, WithUnresolvedSteps):
             return o.construct(workspace)
         elif isinstance(o, (list, tuple, set)):
@@ -461,6 +472,8 @@ class Step(Registrable, Generic[T]):
         def dependencies_internal(o: Any) -> Iterable[Step]:
             if isinstance(o, Step):
                 yield o
+            elif isinstance(o, Lazy):
+                yield from dependencies_internal(o._params.as_dict(quiet=True))
             elif isinstance(o, WithUnresolvedSteps):
                 yield from dependencies_internal(o.args)
                 yield from dependencies_internal(o.kwargs)
@@ -593,6 +606,12 @@ class WithUnresolvedSteps(CustomDetHash):
         """
         if isinstance(o, Step):
             return o.result(workspace)
+        elif isinstance(o, Lazy):
+            return Lazy(
+                o._constructor,
+                params=Params(cls.with_resolved_steps(o._params.as_dict(quiet=True), workspace)),
+                constructor_extras=cls.with_resolved_steps(o._constructor_extras, workspace),
+            )
         elif isinstance(o, cls):
             return o.construct(workspace)
         elif isinstance(o, (dict, Params)):

--- a/tests/end_to_end/test_lazy_input_with_another_step.py
+++ b/tests/end_to_end/test_lazy_input_with_another_step.py
@@ -1,0 +1,58 @@
+from dataclasses import dataclass
+
+from tango import Format, JsonFormat, Step
+from tango.common import FromParams, Lazy
+from tango.common.testing import run_experiment
+
+
+@dataclass
+class Foo(FromParams):
+    number: float
+
+
+@Step.register("generate_number")
+class GenerateNumberStep(Step):
+    DETERMINISTIC = True
+    CACHEABLE = True
+    FORMAT: Format = JsonFormat()
+
+    def run(self) -> float:  # type: ignore[override]
+        return 1.0
+
+
+@Step.register("lazy_input")
+class StepWithLazyInput(Step):
+    DETERMINISTIC = True
+    CACHEABLE = True
+    FORMAT: Format = JsonFormat()
+
+    def run(self, foo: Lazy[Foo]) -> float:  # type: ignore[override]
+        foo = foo.construct()
+        assert isinstance(foo, Foo)
+        assert isinstance(foo.number, float)
+        return foo.number
+
+
+def test_experiment():
+    with run_experiment(
+        {
+            "steps": {
+                "gen_number": {
+                    "type": "generate_number",
+                },
+                "get_number": {
+                    "type": "lazy_input",
+                    "foo": {
+                        "number": {
+                            "type": "ref",
+                            "ref": "gen_number",
+                        }
+                    },
+                },
+            }
+        }
+    ) as run_dir:
+        assert (run_dir / "get_number").is_dir()
+        fmt: Format = JsonFormat()
+        data = fmt.read(run_dir / "get_number")
+        assert data == 1.0


### PR DESCRIPTION
Fixes a bug that happens when a step has a `Lazy` parameter and that `Lazy` object depends on the result from another step.