### PR TITLE
Improvements to W&B callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `SqliteDictFormat` for datasets.
 
+### Changed
+
+- `WandbTrainCallback` now will use part of the step's unique ID as the name for the W&B run by default, to make
+  it easier to indentify which tango step corresponds to each run in W&B.
+- `WandbTrainCallback` will save the entire `TrainConfig` object to the W&B config.
+
 ## [v0.4.0rc2](https://github.com/allenai/tango/releases/tag/v0.4.0rc2) - 2021-12-13
 
 ### Added

--- a/tango/integrations/torch/train.py
+++ b/tango/integrations/torch/train.py
@@ -210,6 +210,7 @@ class TorchTrainStep(Step):
             )
 
         config = TrainConfig(
+            self.unique_id,
             self.work_dir,
             train_split=train_split,
             validation_split=validation_split,

--- a/tango/integrations/torch/train_config.py
+++ b/tango/integrations/torch/train_config.py
@@ -1,6 +1,6 @@
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 import torch
 
@@ -9,6 +9,11 @@ import torch
 class TrainConfig:
     """
     Encapsulates the parameters of :class:`TorchTrainStep`.
+    """
+
+    step: str
+    """
+    The unique ID of the current step.
     """
 
     work_dir: Path
@@ -188,3 +193,6 @@ class TrainConfig:
     def should_log_this_val_step(self, val_step: int) -> bool:
         assert self.validation_steps is not None
         return val_step % self.log_every == 0 or val_step == self.validation_steps - 1
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {k: v for k, v in asdict(self).items() if not k.startswith("_")}

--- a/tango/integrations/wandb/torch_train_callback.py
+++ b/tango/integrations/wandb/torch_train_callback.py
@@ -71,6 +71,7 @@ class WandbTrainCallback(TrainCallback):
             )
 
         _wandb_config = self.train_config.as_dict()
+        _wandb_config["work_dir"] = str(self.train_config.work_dir.resolve())
         if wandb_config is not None:
             _wandb_config.update(wandb_config)
 


### PR DESCRIPTION
<!-- To ensure we can review your pull request promptly please complete this template entirely. -->

<!-- Please reference the issue number here. You can replace "Fixes" with "Closes" if it makes more sense. -->
Followup to a discussion we had a couple weeks ago @dirkgr.

Changes proposed in this pull request:
<!-- Please list all changes/additions here. -->
- The W&B `TorchTrainCallback` will use part of the step's unique ID as the run name in W&B dashboard so that it's easy to figure out which tango step a given W&B run corresponds to.
- It will also save the whole `TrainConfig` object to the W&B config.

Check out [these runs](https://wandb.ai/allennlp/tango-gpt2-train?workspace=user-epwalsh) for an example.

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [ ] I've read and followed all steps in the [Making a pull request](https://github.com/allenai/tango/blob/main/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [ ] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/allenai/tango/blob/main/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.

## After submitting

<!-- Please complete this checklist AFTER submitting your PR to speed along the review process. -->
- [ ] All GitHub Actions jobs for my pull request have passed.
