### PR TITLE
make `--include-package` accept paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The web UI now renders the step graph left-to-right.
 - The web UI now shows runs by date, with the most recent run at the top.
 - The web UI now shows steps in a color-coded way.
+- The `--include-package` flag now also accepts paths instead of module names.
 
 ### Fixed
 

--- a/tests/common/util_test.py
+++ b/tests/common/util_test.py
@@ -1,4 +1,5 @@
 import time
+from pathlib import Path
 
 import pytest
 from flaky import flaky
@@ -7,8 +8,32 @@ from tango.common.util import (
     could_be_class_name,
     find_integrations,
     find_submodules,
+    resolve_module_name,
     threaded_generator,
 )
+
+
+@pytest.mark.parametrize(
+    "package_name, resolved_package_name, resolved_base_path",
+    [
+        (
+            "tango/integrations/datasets/__init__.py",
+            "tango.integrations.datasets",
+            Path("."),
+        ),
+        (
+            "tango/__init__.py",
+            "tango",
+            Path("."),
+        ),
+        ("tango/steps/dataset_remix.py", "tango.steps.dataset_remix", Path(".")),
+        ("examples/train_gpt2/components.py", "components", Path("examples/train_gpt2/")),
+    ],
+)
+def test_resolve_module_name(
+    package_name: str, resolved_package_name: str, resolved_base_path: Path
+):
+    assert resolve_module_name(package_name) == (resolved_package_name, resolved_base_path)
 
 
 def test_find_submodules():


### PR DESCRIPTION
Now you can do something things like:

```
tango run examples/train_gpt2/config.jsonnet -i examples/train_gpt2/components.py
```

This wouldn't work before. You'd have to `cd` into the `examples/train_gpt2` directory and `-i components` unless you added `examples/train_gpt2` to your `PYTHONPATH`.

Besides giving you more flexibility with where you run `tango run ...` from, it also lets you use your shell's path-autocomplete to find packages to include.