### PR TITLE
push Docker images to GHCR.io

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,6 +200,7 @@ jobs:
         cuda: ['11.5.1']
     env:
       IMAGE_NAME: ghcr.io/allenai/tango
+      DOCKER_BUILDKIT: 1
     steps:
       - uses: actions/checkout@v2
 
@@ -212,12 +213,12 @@ jobs:
           docker run --rm "${IMAGE_NAME}:cuda${{ matrix.cuda }}" info
 
       - name: Log in to ghcr.io
-        if: github.event_name != 'pull_request'
+        # if: github.event_name != 'pull_request'
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Push latest to ghcr.io
-        if: github.event_name != 'pull_request'
+        # if: github.event_name != 'pull_request'
         run: |
           docker push "${IMAGE_NAME}:cuda${{ matrix.cuda }}"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,14 +203,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Pull last build from ghcr.io
-        continue-on-error: ${{ !startsWith(github.ref, 'refs/tags/') }}
-        run: |
-          docker pull "${IMAGE_NAME}:cuda${{ matrix.cuda }}"
-
       - name: Build Docker image
         run: |
-          docker build --cache-from "${IMAGE_NAME}:cuda${{ matrix.cuda }}" --build-arg cuda=${{ matrix.cuda }} -t "${IMAGE_NAME}:cuda${{ matrix.cuda }}" .
+          docker build --cache-from "${IMAGE_NAME}:cuda${{ matrix.cuda }}" --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg cuda=${{ matrix.cuda }} -t "${IMAGE_NAME}:cuda${{ matrix.cuda }}" .
 
       - name: Test Docker image
         run: |
@@ -230,8 +225,8 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         run: |
           GITHUB_TAG=${GITHUB_REF#refs/tags/}
-          docker tag "${IMAGE_NAME}:cuda${{ matrix.cuda }}" "${IMAGE_NAME}:${GITHUB_TAG}"
-          docker push "${IMAGE_NAME}:${GITHUB_TAG}"
+          docker tag "${IMAGE_NAME}:cuda${{ matrix.cuda }}" "${IMAGE_NAME}:${GITHUB_TAG}-cuda${{ matrix.cuda }}"
+          docker push "${IMAGE_NAME}:${GITHUB_TAG}-cuda${{ matrix.cuda }}"
 
   release:
     name: Release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,13 +197,35 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Pull last build from ghcr.io
+        continue-on-error: ${{ !startsWith(github.ref, 'refs/tags/') }}
+        run: |
+          docker pull "ghcr.io/allenai/tango:latest"
+
       - name: Build Docker image
         run: |
-          docker build -t tango .
+          docker build --cache-from "ghcr.io/allenai/tango:latest" -t "ghcr.io/allenai/tango:latest" .
 
       - name: Test Docker image
         run: |
-          docker run --rm tango info
+          docker run --rm "ghcr.io/allenai/tango:latest" info
+
+      - name: Log in to ghcr.io
+        if: github.event_name != 'pull_request'
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Push latest to ghcr.io
+        if: github.event_name != 'pull_request'
+        run: |
+          docker push "ghcr.io/allenai/tango:latest"
+
+      - name: Push release version to ghcr.io
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          GITHUB_TAG=${GITHUB_REF#refs/tags/}
+          docker tag "ghcr.io/allenai/tango:latest" "ghcr.io/allenai/tango:$GITHUB_TAG"
+          docker push "ghcr.io/allenai/tango:$GITHUB_TAG"
 
   release:
     name: Release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,7 +192,7 @@ jobs:
           pip uninstall -y ai2-tango
 
   docker:
-    name: Docker
+    name: Docker (CUDA ${{ matrix.cuda }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -236,7 +236,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    needs: [checks]
+    needs: [checks, docker]
     if: startsWith(github.ref, 'refs/tags/')
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,12 +213,12 @@ jobs:
           docker run --rm "${IMAGE_NAME}:cuda${{ matrix.cuda }}" info
 
       - name: Log in to ghcr.io
-        # if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request'
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Push latest to ghcr.io
-        # if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request'
         run: |
           docker push "${IMAGE_NAME}:cuda${{ matrix.cuda }}"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,21 +194,27 @@ jobs:
   docker:
     name: Docker
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        cuda: ['11.5.1']
+    env:
+      IMAGE_NAME: ghcr.io/allenai/tango
     steps:
       - uses: actions/checkout@v2
 
       - name: Pull last build from ghcr.io
         continue-on-error: ${{ !startsWith(github.ref, 'refs/tags/') }}
         run: |
-          docker pull "ghcr.io/allenai/tango:latest"
+          docker pull "${IMAGE_NAME}:cuda${{ matrix.cuda }}"
 
       - name: Build Docker image
         run: |
-          docker build --cache-from "ghcr.io/allenai/tango:latest" -t "ghcr.io/allenai/tango:latest" .
+          docker build --cache-from "${IMAGE_NAME}:cuda${{ matrix.cuda }}" --build-arg cuda=${{ matrix.cuda }} -t "${IMAGE_NAME}:cuda${{ matrix.cuda }}" .
 
       - name: Test Docker image
         run: |
-          docker run --rm "ghcr.io/allenai/tango:latest" info
+          docker run --rm "${IMAGE_NAME}:cuda${{ matrix.cuda }}" info
 
       - name: Log in to ghcr.io
         if: github.event_name != 'pull_request'
@@ -218,14 +224,14 @@ jobs:
       - name: Push latest to ghcr.io
         if: github.event_name != 'pull_request'
         run: |
-          docker push "ghcr.io/allenai/tango:latest"
+          docker push "${IMAGE_NAME}:cuda${{ matrix.cuda }}"
 
       - name: Push release version to ghcr.io
         if: startsWith(github.ref, 'refs/tags/')
         run: |
           GITHUB_TAG=${GITHUB_REF#refs/tags/}
-          docker tag "ghcr.io/allenai/tango:latest" "ghcr.io/allenai/tango:$GITHUB_TAG"
-          docker push "ghcr.io/allenai/tango:$GITHUB_TAG"
+          docker tag "${IMAGE_NAME}:cuda${{ matrix.cuda }}" "${IMAGE_NAME}:${GITHUB_TAG}"
+          docker push "${IMAGE_NAME}:${GITHUB_TAG}"
 
   release:
     name: Release

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@
 # image accordingly and also potentially adjust the PyTorch install line below.
 # See https://hub.docker.com/r/nvidia/cuda/tags for a list of available base images.
 # Generally the "runtime" images are best suited for tango projects.
-FROM nvidia/cuda:11.5.1-cudnn8-runtime-ubuntu20.04
+ARG cuda=11.5.1
+FROM nvidia/cuda:${cuda}-cudnn8-runtime-ubuntu20.04
 
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8

--- a/README.md
+++ b/README.md
@@ -121,6 +121,9 @@ to check your installation.
 You can build a Docker image suitable for tango projects by using [the official Dockerfile](https://github.com/allenai/tango/blob/main/Dockerfile) as a starting point for your own Dockerfile, or you can simply use one of our [prebuilt images](https://github.com/allenai/tango/pkgs/container/tango) as a base image in your Dockerfile. For example:
 
 ```Dockerfile
+# Start from a prebuilt tango base image.
+# You can choose the right tag from the available options here:
+# https://github.com/allenai/tango/pkgs/container/tango/versions
 FROM ghcr.io/allenai/tango:cuda11.5.1
 
 # Install your project's additional requirements.
@@ -128,8 +131,14 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Install source code.
+# This instruction copies EVERYTHING in the current directory (build context),
+# which may not be what you want. Consider using a ".dockerignore" file to
+# exclude files and directories that you don't want on the image.
 COPY . .
 ```
+
+Make sure to choose the right base image for your use case depending on the version of tango you're using and the CUDA version that your host machine supports.
+You can see a list of all available image tags [on GitHub](https://github.com/allenai/tango/pkgs/container/tango/versions).
 
 <!-- end install -->
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,21 @@ tango info
 
 to check your installation.
 
+### Docker image
+
+You can build a Docker image suitable for tango projects by using [the official Dockerfile](https://github.com/allenai/tango/blob/main/Dockerfile) as a starting point for your own Dockerfile, or you can simply use one of our [prebuilt images](https://github.com/allenai/tango/pkgs/container/tango) as a base image in your Dockerfile. For example:
+
+```Dockerfile
+FROM ghcr.io/allenai/tango:cuda11.5.1
+
+# Install your project's additional requirements.
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Install source code.
+COPY . .
+```
+
 <!-- end install -->
 
 ## FAQ


### PR DESCRIPTION
#162 Added a Dockerfile, this PR pushes images built from that Dockerfile to GitHub's [container registry](https://github.com/allenai/tango/pkgs/container/tango) on every commit and release, and adds information to the README and docs about using the Dockerfile and pre-built images for users' own projects.