### PR TITLE
more fixes for conda-forge

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ petname>=2.6,<3.0
 # that you install with 'pip install tango[torch]'.
 torch>=1.9,<1.11             # needed by: torch,pytorch_lightning
 numpy                        # needed by: torch
-datasets>=1.12,<2            # needed by: datasets
+datasets>=1.12,<2            # needed by: datasets,transformers
 wandb>=0.12,<0.13            # needed by: wandb
 pytorch-lightning>=1.5,<1.6  # needed by: pytorch_lightning
 transformers>=4.12.3         # needed by: transformers

--- a/tests/integrations/torch/train_test.py
+++ b/tests/integrations/torch/train_test.py
@@ -3,14 +3,20 @@ import json
 import pytest
 import torch.distributed as dist
 
+from tango.common.logging import initialize_logging, teardown_logging
 from tango.common.testing import TangoTestCase
 
 
 class TestTrainStep(TangoTestCase):
+    def setup_method(self):
+        super().setup_method()
+        initialize_logging(enable_click_logs=True)
+
     def teardown_method(self):
         super().teardown_method()
         if dist.is_initialized():
             dist.destroy_process_group()
+        teardown_logging()
 
     @pytest.mark.parametrize("with_validation", [True, False])
     def test_basic_train(self, with_validation: bool):


### PR DESCRIPTION
- Adds missing `datasets` as a requirement for `transformers` integration.
- Fixes `tests/integrations/torch/train_test.py` when ran by itself.