### PR TITLE
split Docker build into seperate workflow, only run when necessary

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,56 @@
+name: Docker
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'Dockerfile'
+      - '.dockerignore'
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  build:
+    name: Build (${{ matrix.build.tag }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        build:
+          - base_image: ghcr.io/allenai/pytorch:1.10.2-cuda11.3
+            tag: cuda11.3
+    env:
+      IMAGE_NAME: ghcr.io/allenai/tango
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build Docker image
+        run: |
+          docker build --build-arg BASE_IMAGE=${{ matrix.build.base_image }} -t "${IMAGE_NAME}:${{ matrix.build.tag }}" .
+
+      - name: Test Docker image
+        run: |
+          docker run --rm "${IMAGE_NAME}:${{ matrix.build.tag }}" info
+
+      - name: Log in to ghcr.io
+        if: github.event_name != 'pull_request'
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Push latest to ghcr.io
+        if: github.event_name != 'pull_request'
+        run: |
+          docker push "${IMAGE_NAME}:${{ matrix.build.tag }}"
+
+      - name: Push release version to ghcr.io
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          GITHUB_TAG=${GITHUB_REF#refs/tags/}
+          docker tag "${IMAGE_NAME}:${{ matrix.build.tag }}" "${IMAGE_NAME}:${GITHUB_TAG}-${{ matrix.build.tag }}"
+          docker push "${IMAGE_NAME}:${GITHUB_TAG}-${{ matrix.build.tag }}"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,6 +11,8 @@ on:
     paths:
       - 'Dockerfile'
       - '.dockerignore'
+      - 'requirements.txt'
+      - 'setup.py'
   push:
     tags:
       - 'v*.*.*'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -191,55 +191,10 @@ jobs:
           . .venv/bin/activate
           pip uninstall -y ai2-tango
 
-  docker:
-    name: Docker (${{ matrix.build.tag }})
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        build:
-          - base_image: ghcr.io/allenai/pytorch:1.10.2-cuda11.3
-            tag: cuda11.3
-    env:
-      IMAGE_NAME: ghcr.io/allenai/tango
-      # DOCKER_BUILDKIT: 1
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Pull last image
-        continue-on-error: true
-        run: |
-          docker pull "${IMAGE_NAME}:${{ matrix.build.tag }}"
-
-      - name: Build Docker image
-        run: |
-          docker build --build-arg BASE_IMAGE=${{ matrix.build.base_image }} -t "${IMAGE_NAME}:${{ matrix.build.tag }}" .
-
-      - name: Test Docker image
-        run: |
-          docker run --rm "${IMAGE_NAME}:${{ matrix.build.tag }}" info
-
-      - name: Log in to ghcr.io
-        if: github.event_name != 'pull_request'
-        run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-
-      - name: Push latest to ghcr.io
-        if: github.event_name != 'pull_request'
-        run: |
-          docker push "${IMAGE_NAME}:${{ matrix.build.tag }}"
-
-      - name: Push release version to ghcr.io
-        if: startsWith(github.ref, 'refs/tags/')
-        run: |
-          GITHUB_TAG=${GITHUB_REF#refs/tags/}
-          docker tag "${IMAGE_NAME}:${{ matrix.build.tag }}" "${IMAGE_NAME}:${GITHUB_TAG}-${{ matrix.build.tag }}"
-          docker push "${IMAGE_NAME}:${GITHUB_TAG}-${{ matrix.build.tag }}"
-
   release:
     name: Release
     runs-on: ubuntu-latest
-    needs: [checks, docker]
+    needs: [checks]
     if: startsWith(github.ref, 'refs/tags/')
     steps:
       - uses: actions/checkout@v1

--- a/README.md
+++ b/README.md
@@ -124,11 +124,11 @@ You can build a Docker image suitable for tango projects by using [the official 
 # Start from a prebuilt tango base image.
 # You can choose the right tag from the available options here:
 # https://github.com/allenai/tango/pkgs/container/tango/versions
-FROM ghcr.io/allenai/tango:cuda11.5.1
+FROM ghcr.io/allenai/tango:cuda11.3
 
 # Install your project's additional requirements.
 COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN /opt/conda/bin/pip install --no-cache-dir -r requirements.txt
 
 # Install source code.
 # This instruction copies EVERYTHING in the current directory (build context),


### PR DESCRIPTION
<!-- To ensure we can review your pull request promptly please complete this template entirely. -->


Changes proposed in this pull request:
<!-- Please list all changes/additions here. -->
- Small organizational improvements: renamed workflow `ci.yml` to `main.yml` and moved the Docker build job within that workflow to its own workflow called `docker.yml`.
- The Docker build will only run on releases and for pull requests that involve changes to the `Dockerfile`, `setup.py`, `requirements.txt`, or `.dockerignore`, because building on every PR and commit to `main` is extremely time-consuming and wasteful.