### PR TITLE
Rename "ExecutorMetadata" -> "StepExecutionMetadata"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a '@requires_gpus' decorator for marking tests as needing GPUs. Tests marked with this will be run in the "GPU Tests" workflow
   on dual k80 GPUs via Beaker.
 
+### Changed
+
+- `local_workspace.ExecutorMetadata` renamed to `StepExecutionMetadata` and now saved as `execution-metadata.json`.
+
 ### Fixed
 
 - Fixed a small bug `LocalWorkspace` would fail to capture the conda environment in our Docker image.

--- a/docs/source/api/components/workspace.rst
+++ b/docs/source/api/components/workspace.rst
@@ -23,7 +23,7 @@ Metadata
 .. autoclass:: tango.workspace.StepInfo
    :members:
 
-.. autoclass:: tango.local_workspace.ExecutorMetadata
+.. autoclass:: tango.local_workspace.StepExecutionMetadata
    :members:
 
 .. autoclass:: tango.local_workspace.TangoMetadata

--- a/tango/local_workspace.py
+++ b/tango/local_workspace.py
@@ -117,7 +117,7 @@ class TangoMetadata(FromParams):
 
 
 @dataclass
-class ExecutorMetadata(FromParams):
+class StepExecutionMetadata(FromParams):
     step: str
     """
     The unique ID of the step.
@@ -220,7 +220,7 @@ class ExecutorMetadata(FromParams):
         self._save_conda(run_dir)
 
         # Serialize self.
-        self.to_params().to_file(run_dir / "executor-metadata.json")
+        self.to_params().to_file(run_dir / "execution-metadata.json")
 
 
 @Workspace.register("local")
@@ -470,7 +470,7 @@ class LocalWorkspace(Workspace):
                 config = step.config
             except ValueError:
                 config = None
-            metadata = ExecutorMetadata(
+            metadata = StepExecutionMetadata(
                 step=step.unique_id, config=replace_steps_with_unique_id(config)
             )
             # Finalize metadata and save to run directory.

--- a/tests/executor_test.py
+++ b/tests/executor_test.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from tango.common.params import Params
 from tango.common.testing import TangoTestCase
 from tango.executor import Executor
-from tango.local_workspace import ExecutorMetadata, LocalWorkspace
+from tango.local_workspace import LocalWorkspace, StepExecutionMetadata
 from tango.step import Step
 
 
@@ -18,7 +18,7 @@ class AdditionStep(Step):
 
 class TestMetadata(TangoTestCase):
     def test_metadata(self):
-        metadata = ExecutorMetadata("some_step")
+        metadata = StepExecutionMetadata("some_step")
         metadata.save(self.TEST_DIR)
 
         if (Path.cwd() / ".git").exists():
@@ -27,7 +27,7 @@ class TestMetadata(TangoTestCase):
             assert metadata.git.remote is not None
             assert "allenai/tango" in metadata.git.remote
 
-        metadata2 = ExecutorMetadata.from_params(
+        metadata2 = StepExecutionMetadata.from_params(
             Params.from_file(self.TEST_DIR / "executor-metadata.json")
         )
         assert metadata == metadata2

--- a/tests/executor_test.py
+++ b/tests/executor_test.py
@@ -28,7 +28,7 @@ class TestMetadata(TangoTestCase):
             assert "allenai/tango" in metadata.git.remote
 
         metadata2 = StepExecutionMetadata.from_params(
-            Params.from_file(self.TEST_DIR / "executor-metadata.json")
+            Params.from_file(self.TEST_DIR / "execution-metadata.json")
         )
         assert metadata == metadata2
 

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -9,7 +9,7 @@ import pytest
 
 from tango.common import Params
 from tango.common.testing import TangoTestCase
-from tango.local_workspace import ExecutorMetadata
+from tango.local_workspace import StepExecutionMetadata
 from tango.version import VERSION
 
 
@@ -88,7 +88,7 @@ class TestMain(TangoTestCase):
         metadata_path = run_dir / "hello_world" / "executor-metadata.json"
         assert metadata_path.is_file()
         metadata_params = Params.from_file(metadata_path)
-        metadata = ExecutorMetadata.from_params(metadata_params)
+        metadata = StepExecutionMetadata.from_params(metadata_params)
         assert metadata.config == {
             "type": "concat_strings",
             "string1": {"type": "ref", "ref": "StringStep-4cHbmoHigd3rvNn3w7shc1d45WA1ijSp"},

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -81,11 +81,11 @@ class TestMain(TangoTestCase):
         run_dir = next((self.TEST_DIR / "runs").iterdir())
         assert (run_dir / "hello").is_dir()
         assert (run_dir / "hello" / "cache-metadata.json").is_file()
-        assert (run_dir / "hello" / "executor-metadata.json").is_file()
+        assert (run_dir / "hello" / "execution-metadata.json").is_file()
         assert (run_dir / "hello_world").is_dir()
 
         # Check metadata.
-        metadata_path = run_dir / "hello_world" / "executor-metadata.json"
+        metadata_path = run_dir / "hello_world" / "execution-metadata.json"
         assert metadata_path.is_file()
         metadata_params = Params.from_file(metadata_path)
         metadata = StepExecutionMetadata.from_params(metadata_params)


### PR DESCRIPTION
This just makes more sense now that this class is decoupled from the `Executor`.