### PR TITLE
Changes to allow support for more Workspace and StepCache implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New example that finetunes a pre-trained ResNet model on the Cats & Dogs dataset.
 - Added a '@requires_gpus' decorator for marking tests as needing GPUs. Tests marked with this will be run in the "GPU Tests" workflow
   on dual k80 GPUs via Beaker.
+- Added the "-w/--workspace" option to `tango run` and `tango server` commands. This option takes a URL, and instantiates the workspace from the URL using the newly added `Workspace.from_url()` method.
+- Added the "workspace" field to `TangoGlobalSettings`.
 - Added a utility function to get a `StepGraph` directly from a file.
 
 ### Changed
 
 - `local_workspace.ExecutorMetadata` renamed to `StepExecutionMetadata` and now saved as `execution-metadata.json`.
+- Renamed `common.logging.file_handler()` to `with_file_handler()`.
+- `tango run` without the option "-w/--workspace" or "-d/--workspace-dir" will now use a `MemoryWorkspace` instead of a `LocalWorkspace` in a temp directory, unless you've specified
+  a default workspace in a `TangoGlobalSettings` file.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Renamed `common.logging.file_handler()` to `with_file_handler()`.
 - `tango run` without the option "-w/--workspace" or "-d/--workspace-dir" will now use a `MemoryWorkspace` instead of a `LocalWorkspace` in a temp directory, unless you've specified
   a default workspace in a `TangoGlobalSettings` file.
+- Moved `tango.workspace.MemoryWorkspace` and `tango.local_workspace.LocalWorkspace` to `tango.workspaces.*`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `local_workspace.ExecutorMetadata` renamed to `StepExecutionMetadata` and now saved as `execution-metadata.json`.
-- Renamed `common.logging.file_handler()` to `with_file_handler()`.
 - `tango run` without the option "-w/--workspace" or "-d/--workspace-dir" will now use a `MemoryWorkspace` instead of a `LocalWorkspace` in a temp directory, unless you've specified
   a default workspace in a `TangoGlobalSettings` file.
 - Moved `tango.workspace.MemoryWorkspace` and `tango.local_workspace.LocalWorkspace` to `tango.workspaces.*`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New example that finetunes a pre-trained ResNet model on the Cats & Dogs dataset.
 - Added a '@requires_gpus' decorator for marking tests as needing GPUs. Tests marked with this will be run in the "GPU Tests" workflow
   on dual k80 GPUs via Beaker.
-- Added the "-w/--workspace" option to `tango run` and `tango server` commands. This option takes a URL, and instantiates the workspace from the URL using the newly added `Workspace.from_url()` method.
+- Added the "-w/--workspace" option to `tango run` and `tango server` commands. This option takes a path or URL, and instantiates the workspace from the URL using the newly added `Workspace.from_url()` method.
 - Added the "workspace" field to `TangoGlobalSettings`.
 - Added a utility function to get a `StepGraph` directly from a file.
 
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a default workspace in a `TangoGlobalSettings` file.
 - Moved `tango.workspace.MemoryWorkspace` and `tango.local_workspace.LocalWorkspace` to `tango.workspaces.*`.
 - Moved `tango.step_cache.MemoryStepCache` and `tango.step_cache.LocalStepCache` to `tango.step_caches.*`.
+- Deprecated the `-d/--workspace-dir` command-line option. Please use `-w/--workspace` instead.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `tango run` without the option "-w/--workspace" or "-d/--workspace-dir" will now use a `MemoryWorkspace` instead of a `LocalWorkspace` in a temp directory, unless you've specified
   a default workspace in a `TangoGlobalSettings` file.
 - Moved `tango.workspace.MemoryWorkspace` and `tango.local_workspace.LocalWorkspace` to `tango.workspaces.*`.
+- Moved `tango.step_cache.MemoryStepCache` and `tango.step_cache.LocalStepCache` to `tango.step_caches.*`.
 
 ### Fixed
 

--- a/docs/source/api/components/step_cache.rst
+++ b/docs/source/api/components/step_cache.rst
@@ -8,16 +8,16 @@ Base class
    :members: 
    :special-members:
 
+Implementations
+---------------
+
+.. autoclass:: tango.step_caches.LocalStepCache
+   :members:
+
+.. autoclass:: tango.step_caches.MemoryStepCache
+
 Metadata
 --------
 
 .. autoclass:: tango.step_cache.CacheMetadata
-   :members:
-
-Implementations
----------------
-
-.. autoclass:: tango.step_cache.MemoryStepCache
-
-.. autoclass:: tango.step_cache.LocalStepCache
    :members:

--- a/docs/source/api/components/workspace.rst
+++ b/docs/source/api/components/workspace.rst
@@ -10,27 +10,30 @@ Base class
 Implementations
 ---------------
 
-.. autoclass:: tango.workspace.MemoryWorkspace
+.. autoclass:: tango.workspaces.LocalWorkspace
 
-.. autoclass:: tango.local_workspace.LocalWorkspace
+.. autoclass:: tango.workspaces.MemoryWorkspace
 
 Metadata
 --------
 
-.. autoclass:: tango.workspace.StepState
-   :members:
-
 .. autoclass:: tango.workspace.StepInfo
    :members:
 
-.. autoclass:: tango.local_workspace.StepExecutionMetadata
+.. autoclass:: tango.workspace.StepState
    :members:
 
-.. autoclass:: tango.local_workspace.TangoMetadata
+.. autoclass:: tango.workspace.Run
    :members:
 
-.. autoclass:: tango.local_workspace.PlatformMetadata
+.. autoclass:: tango.workspace.StepExecutionMetadata
    :members:
 
-.. autoclass:: tango.local_workspace.GitMetadata
+.. autoclass:: tango.workspace.TangoMetadata
+   :members:
+
+.. autoclass:: tango.workspace.PlatformMetadata
+   :members:
+
+.. autoclass:: tango.workspace.GitMetadata
    :members:

--- a/docs/source/api/logging.rst
+++ b/docs/source/api/logging.rst
@@ -18,8 +18,8 @@ Reference
 
 .. autofunction:: tango.common.logging.teardown_logging
 
-.. autofunction:: tango.common.logging.with_handler
+.. autofunction:: tango.common.logging.insert_handler
 
-.. autofunction:: tango.common.logging.with_file_handler
+.. autofunction:: tango.common.logging.file_handler
 
 .. autoclass:: tango.common.logging.TangoLogger

--- a/docs/source/api/logging.rst
+++ b/docs/source/api/logging.rst
@@ -18,6 +18,8 @@ Reference
 
 .. autofunction:: tango.common.logging.teardown_logging
 
-.. autofunction:: tango.common.logging.file_handler
+.. autofunction:: tango.common.logging.with_handler
+
+.. autofunction:: tango.common.logging.with_file_handler
 
 .. autoclass:: tango.common.logging.TangoLogger

--- a/tango/__init__.py
+++ b/tango/__init__.py
@@ -14,8 +14,6 @@ __all__ = [
     "StepCache",
     "LocalStepCache",
     "Workspace",
-    "MemoryWorkspace",
-    "LocalWorkspace",
 ]
 
 from tango.executor import Executor
@@ -27,8 +25,7 @@ from tango.format import (
     JsonFormatIterator,
     SqliteDictFormat,
 )
-from tango.local_workspace import LocalWorkspace
 from tango.step import Step
 from tango.step_cache import LocalStepCache, StepCache
 from tango.step_graph import StepGraph
-from tango.workspace import MemoryWorkspace, Workspace
+from tango.workspace import Workspace

--- a/tango/__init__.py
+++ b/tango/__init__.py
@@ -12,7 +12,6 @@ __all__ = [
     "SqliteDictFormat",
     "Step",
     "StepCache",
-    "LocalStepCache",
     "Workspace",
 ]
 
@@ -26,6 +25,6 @@ from tango.format import (
     SqliteDictFormat,
 )
 from tango.step import Step
-from tango.step_cache import LocalStepCache, StepCache
+from tango.step_cache import StepCache
 from tango.step_graph import StepGraph
 from tango.workspace import Workspace

--- a/tango/__main__.py
+++ b/tango/__main__.py
@@ -245,7 +245,7 @@ def cleanup(*args, **kwargs):
     "-w",
     "--workspace",
     type=click.Path(file_okay=False),
-    help="""A workspace URL. If not specified, the workspace from any global tango
+    help="""A workspace path or URL. If not specified, the workspace from any global tango
     settings file will be used, if found, otherwise an ephemeral MemoryWorkspace.""",
     default=None,
 )
@@ -253,8 +253,6 @@ def cleanup(*args, **kwargs):
     "-d",
     "--workspace-dir",
     type=click.Path(file_okay=False),
-    help="""[DEPRECATED] The directory of the workspace in which to work. If not specified,
-    a named temporary directory will be created.""",
     default=None,
     hidden=True,
 )
@@ -294,10 +292,18 @@ def run(
     EXPERIMENT is the path to experiment's JSON/Jsonnet/YAML configuration file.
     """
     if workspace_dir is not None:
+        import warnings
+
+        warnings.warn(
+            "-d/--workspace-dir option is deprecated. Please use -w/--workspace instead.",
+            DeprecationWarning,
+        )
+
         if workspace is not None:
             raise click.ClickException(
                 "-w/--workspace is mutually exclusive with -d/--workspace-dir"
             )
+
         workspace = "local://" + str(workspace_dir)
 
     _run(
@@ -328,8 +334,8 @@ def run(
     "-d",
     "--workspace-dir",
     type=click.Path(file_okay=False),
-    help="""The directory of the workspace to monitor.""",
     default=None,
+    hidden=True,
 )
 @click.pass_obj
 def server(

--- a/tango/__main__.py
+++ b/tango/__main__.py
@@ -71,19 +71,14 @@ import multiprocessing as mp
 import os
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Optional, Sequence, Union
+from typing import Any, Dict, List, Optional, Sequence, Union
 
 import click
 from click_help_colors import HelpColorsCommand, HelpColorsGroup
 
 from tango.common.aliases import PathOrStr
 from tango.common.from_params import FromParams
-from tango.common.logging import (
-    click_logger,
-    file_handler,
-    initialize_logging,
-    teardown_logging,
-)
+from tango.common.logging import click_logger, initialize_logging, teardown_logging
 from tango.common.params import Params
 from tango.common.util import import_extra_module
 from tango.version import VERSION
@@ -93,6 +88,11 @@ from tango.version import VERSION
 class TangoGlobalSettings(FromParams):
     """
     Defines global settings for tango.
+    """
+
+    workspace: Optional[Dict[str, Any]] = None
+    """
+    Parameters to initialize a :class:`tango.workspace.Workspace` with.
     """
 
     include_package: Optional[List[str]] = None
@@ -242,12 +242,21 @@ def cleanup(*args, **kwargs):
     type=click.Path(exists=True, dir_okay=False, resolve_path=True),
 )
 @click.option(
+    "-w",
+    "--workspace",
+    type=click.Path(file_okay=False),
+    help="""A workspace URL. If not specified, the workspace from any global tango
+    settings file will be used, if found, otherwise an ephemeral MemoryWorkspace.""",
+    default=None,
+)
+@click.option(
     "-d",
     "--workspace-dir",
     type=click.Path(file_okay=False),
-    help="""The directory of the workspace in which to work. If not specified,
+    help="""[DEPRECATED] The directory of the workspace in which to work. If not specified,
     a named temporary directory will be created.""",
     default=None,
+    hidden=True,
 )
 @click.option(
     "-o",
@@ -273,6 +282,7 @@ def cleanup(*args, **kwargs):
 def run(
     config: TangoGlobalSettings,
     experiment: str,
+    workspace: Optional[str] = None,
     workspace_dir: Optional[Union[str, os.PathLike]] = None,
     overrides: Optional[str] = None,
     include_package: Optional[Sequence[str]] = None,
@@ -283,10 +293,17 @@ def run(
 
     EXPERIMENT is the path to experiment's JSON/Jsonnet/YAML configuration file.
     """
+    if workspace_dir is not None:
+        if workspace is not None:
+            raise click.ClickException(
+                "-w/--workspace is mutually exclusive with -d/--workspace-dir"
+            )
+        workspace = "local://" + str(workspace_dir)
+
     _run(
         config,
         experiment,
-        workspace_dir=workspace_dir,
+        workspace_url=workspace,
         overrides=overrides,
         include_package=include_package,
         start_server=server,
@@ -300,21 +317,51 @@ def run(
     context_settings={"max_content_width": 115},
 )
 @click.option(
+    "-w",
+    "--workspace",
+    type=click.Path(file_okay=False),
+    help="""A workspace URL. If not specified, the workspace from any global tango
+    settings file will be used, if found, otherwise an ephemeral MemoryWorkspace.""",
+    default=None,
+)
+@click.option(
     "-d",
     "--workspace-dir",
     type=click.Path(file_okay=False),
     help="""The directory of the workspace to monitor.""",
+    default=None,
 )
-def server(workspace_dir: Union[str, os.PathLike]):
+@click.pass_obj
+def server(
+    config: TangoGlobalSettings,
+    workspace: Optional[str],
+    workspace_dir: Optional[Union[str, os.PathLike]] = None,
+):
     """
     Run a local webserver that watches a workspace
     """
     from tango.local_workspace import LocalWorkspace
     from tango.server.workspace_server import WorkspaceServer
+    from tango.workspace import Workspace
 
-    workspace_dir = Path(workspace_dir)
-    workspace = LocalWorkspace(workspace_dir)
-    server = WorkspaceServer.on_free_port(workspace)
+    workspace_to_watch: Workspace
+    if workspace_dir is not None:
+        if workspace is not None:
+            raise click.ClickException(
+                "-w/--workspace is mutually exclusive with -d/--workspace-dir"
+            )
+        workspace_to_watch = LocalWorkspace(workspace_dir)
+    elif workspace is not None:
+        workspace_to_watch = Workspace.from_url(workspace)
+    elif config.workspace is not None:
+        workspace_to_watch = Workspace.from_params(config.workspace)
+    else:
+        raise click.ClickException(
+            "-w/--workspace or -d/--workspace-dir required unless a default workspace is specified "
+            "in tango settings file."
+        )
+
+    server = WorkspaceServer.on_free_port(workspace_to_watch)
     click_logger.info("Server started at " + click.style(server.address_for_display(), bold=True))
     server.serve_forever()
 
@@ -375,15 +422,15 @@ def info(config: TangoGlobalSettings):
 def _run(
     config: TangoGlobalSettings,
     experiment: str,
-    workspace_dir: Optional[Union[str, os.PathLike]] = None,
+    workspace_url: Optional[str] = None,
     overrides: Optional[str] = None,
     include_package: Optional[Sequence[str]] = None,
     start_server: bool = True,
-) -> Path:
+) -> str:
     from tango.executor import Executor
-    from tango.local_workspace import LocalWorkspace
     from tango.server.workspace_server import WorkspaceServer
     from tango.step_graph import StepGraph
+    from tango.workspace import Workspace, default_workspace
 
     # Read params.
     params = Params.from_file(experiment, params_overrides=overrides or "")
@@ -398,24 +445,22 @@ def _run(
     for package_name in include_package:
         import_extra_module(package_name)
 
-    # Prepare directory.
-    if workspace_dir is None:
-        from tempfile import mkdtemp
-
-        workspace_dir = mkdtemp(prefix="tango-")
-        click_logger.info(
-            "Creating temporary directory for run: " + click.style(f"{workspace_dir}", fg="yellow")
-        )
-    workspace_dir = Path(workspace_dir)
-    workspace = LocalWorkspace(workspace_dir)
+    # Prepare workspace.
+    workspace: Workspace
+    if workspace_url is not None:
+        workspace = Workspace.from_url(workspace_url)
+    elif config.workspace is not None:
+        workspace = Workspace.from_params(config.workspace)
+    else:
+        workspace = default_workspace
 
     # Initialize step graph and register run.
     step_graph = StepGraph(params.pop("steps", keep_as_dict=True))
+    params.assert_empty("'tango run'")
     run = workspace.register_run(step for step in step_graph.values())
-    run_dir = workspace.run_dir(run.name)
 
     # Capture logs to file.
-    with file_handler(run_dir / "out.log"):
+    with workspace.capture_logs_for_run(run.name):
         click_logger.info(
             click.style("Starting new run ", fg="green")
             + click.style(run.name, fg="green", bold=True)
@@ -436,34 +481,20 @@ def _run(
         # Print everything that has been computed.
         ordered_steps = sorted(step_graph.values(), key=lambda step: step.name)
         for step in ordered_steps:
-            if step in workspace.step_cache:
-                info = workspace.step_info(step)
-                if info.step_name is not None:
-                    path = run_dir / info.step_name
-                elif info.result_location is not None:
-                    path = Path(info.result_location)
-                else:
-                    path = None
-
-                if path is None:
-                    click_logger.warn(
-                        click.style("\N{ballot x} The output for ", fg="red")
-                        + click.style(f'"{step.name}"', bold=True, fg="red")
-                        + click.style(" is missing!", fg="red")
-                    )
-                else:
-                    click_logger.info(
-                        click.style("\N{check mark} The output for ", fg="green")
-                        + click.style(f'"{step.name}"', bold=True, fg="green")
-                        + click.style(" is in ", fg="green")
-                        + click.style(f"{path}", bold=True, fg="green")
-                    )
+            info = workspace.step_info(step)
+            if info.result_location is not None:
+                click_logger.info(
+                    click.style("\N{check mark} The output for ", fg="green")
+                    + click.style(f'"{step.name}"', bold=True, fg="green")
+                    + click.style(" is in ", fg="green")
+                    + click.style(f"{info.result_location}", bold=True, fg="green")
+                )
 
         click_logger.info(
             click.style("Finished run ", fg="green") + click.style(run.name, fg="green", bold=True)
         )
 
-    return run_dir
+    return run.name
 
 
 if __name__ == "__main__":

--- a/tango/__main__.py
+++ b/tango/__main__.py
@@ -340,9 +340,9 @@ def server(
     """
     Run a local webserver that watches a workspace
     """
-    from tango.local_workspace import LocalWorkspace
     from tango.server.workspace_server import WorkspaceServer
     from tango.workspace import Workspace
+    from tango.workspaces import LocalWorkspace
 
     workspace_to_watch: Workspace
     if workspace_dir is not None:
@@ -430,7 +430,8 @@ def _run(
     from tango.executor import Executor
     from tango.server.workspace_server import WorkspaceServer
     from tango.step_graph import StepGraph
-    from tango.workspace import Workspace, default_workspace
+    from tango.workspace import Workspace
+    from tango.workspaces import default_workspace
 
     # Read params.
     params = Params.from_file(experiment, params_overrides=overrides or "")

--- a/tango/common/logging.py
+++ b/tango/common/logging.py
@@ -497,7 +497,7 @@ def teardown_logging():
 
 
 @contextmanager
-def with_handler(handler: logging.Handler):
+def insert_handler(handler: logging.Handler):
     """
     A context manager that can be used to route logs to a specific handler temporarily.
     """
@@ -518,7 +518,7 @@ def with_handler(handler: logging.Handler):
             logger.removeHandler(handler)
 
 
-def with_file_handler(filepath: PathOrStr):
+def file_handler(filepath: PathOrStr):
     """
     A context manager that can be used to route logs to a file by adding a
     :class:`logging.FileHandler` to the root logger's handlers.
@@ -527,18 +527,18 @@ def with_file_handler(filepath: PathOrStr):
 
     .. code-block::
 
-        from tango.common.logging import initialize_logging, with_file_handler, teardown_logging
+        from tango.common.logging import initialize_logging, file_handler, teardown_logging
 
         initialize_logging(log_level="info")
 
         logger = logging.getLogger()
         logger.info("Hi!")
 
-        with with_file_handler("log.out"):
+        with file_handler("log.out"):
             logger.info("This message should also go into 'log.out'")
 
         teardown_logging()
 
     """
     handler = logging.FileHandler(str(filepath))
-    return with_handler(handler)
+    return insert_handler(handler)

--- a/tango/common/logging.py
+++ b/tango/common/logging.py
@@ -87,7 +87,7 @@ import struct
 import sys
 import threading
 from contextlib import contextmanager
-from typing import Optional
+from typing import ContextManager, Generator, Optional
 
 import click
 
@@ -497,7 +497,7 @@ def teardown_logging():
 
 
 @contextmanager
-def insert_handler(handler: logging.Handler):
+def insert_handler(handler: logging.Handler) -> Generator[None, None, None]:
     """
     A context manager that can be used to route logs to a specific handler temporarily.
     """
@@ -518,7 +518,7 @@ def insert_handler(handler: logging.Handler):
             logger.removeHandler(handler)
 
 
-def file_handler(filepath: PathOrStr):
+def file_handler(filepath: PathOrStr) -> ContextManager[None]:
     """
     A context manager that can be used to route logs to a file by adding a
     :class:`logging.FileHandler` to the root logger's handlers.

--- a/tango/common/params.py
+++ b/tango/common/params.py
@@ -431,17 +431,15 @@ class Params(MutableMapping):
         """
         return copy.deepcopy(self)
 
-    def assert_empty(self, class_name: str):
+    def assert_empty(self, name: str):
         """
         Raises a :class:`~tango.common.exceptions.ConfigurationError` if ``self.params`` is not empty.
-        We take ``class_name`` as an argument so that the error message gives some idea of where an error
-        happened, if there was one.  ``class_name`` should be the name of the ``calling`` class, the one
+        We take ``name`` as an argument so that the error message gives some idea of where an error
+        happened, if there was one. For example, ``name`` could be the name of the ``calling`` class
         that got extra parameters (if there are any).
         """
         if self.params:
-            raise ConfigurationError(
-                "Extra parameters passed to {}: {}".format(class_name, self.params)
-            )
+            raise ConfigurationError("Extra parameters passed to {}: {}".format(name, self.params))
 
     def __getitem__(self, key):
         if key in self.params:

--- a/tango/common/testing.py
+++ b/tango/common/testing.py
@@ -75,14 +75,16 @@ class TangoTestCase:
 
             overrides = json.dumps(overrides)
 
-        return _run(
+        run_name = _run(
             TangoGlobalSettings(),
             str(config),
-            workspace_dir=str(self.TEST_DIR / "workspace"),
+            workspace_url="local://" + str(self.TEST_DIR / "workspace"),
             overrides=overrides,
             include_package=include_package,
             start_server=False,
         )
+
+        return self.TEST_DIR / "workspace" / "runs" / run_name
 
 
 @contextmanager

--- a/tango/step.py
+++ b/tango/step.py
@@ -445,7 +445,7 @@ class Step(Registrable, Generic[T]):
 
         If necessary, this method will first produce the results of all steps it depends on."""
         if workspace is None:
-            from tango.workspace import default_workspace
+            from tango.workspaces import default_workspace
 
             workspace = default_workspace
 

--- a/tango/step_cache.py
+++ b/tango/step_cache.py
@@ -1,23 +1,8 @@
-import collections
 import logging
-import weakref
 from abc import abstractmethod
 from dataclasses import dataclass
-from pathlib import Path
-from typing import Any, Dict, MutableMapping, Optional, OrderedDict, TypeVar, Union
+from typing import Any, TypeVar
 
-try:
-    from typing import get_args, get_origin  # type: ignore
-except ImportError:
-
-    def get_origin(tp):  # type: ignore
-        return getattr(tp, "__origin__", None)
-
-    def get_args(tp):  # type: ignore
-        return getattr(tp, "__args__", ())
-
-
-from tango.common.aliases import PathOrStr
 from tango.common.from_params import FromParams
 from tango.common.registrable import Registrable
 from tango.step import Step
@@ -31,11 +16,13 @@ T = TypeVar("T")
 class StepCache(Registrable):
     """
     This is a mapping from instances of :class:`~tango.step.Step` to the results of that step.
+    Generally :class:`StepCache` implementations are used internally by :class:`~tango.workspace.Workspace`
+    implementations.
     """
 
-    default_implementation = "local"
+    default_implementation = "memory"
     """
-    The default implementation is :class:`LocalStepCache`.
+    The default implementation is :class:`.MemoryStepCache`.
     """
 
     def __contains__(self, step: Any) -> bool:
@@ -63,166 +50,6 @@ class StepCache(Registrable):
     def __len__(self) -> int:
         """Returns the number of results saved in this cache."""
         raise NotImplementedError()
-
-
-@StepCache.register("memory")
-class MemoryStepCache(StepCache):
-    """
-    This is a :class:`.StepCache` that stores results in memory. It is little more than a Python dictionary.
-
-    .. tip::
-        Registered as :class:`StepCache` under the name "memory".
-    """
-
-    def __init__(self):
-        self.cache: Dict[str, Any] = {}
-
-    def __getitem__(self, step: Step) -> Any:
-        return self.cache[step.unique_id]
-
-    def __setitem__(self, step: Step, value: Any) -> None:
-        if step in self:
-            raise ValueError(f"{step.unique_id} is already cached! Will not overwrite.")
-        if step.cache_results:
-            self.cache[step.unique_id] = value
-        else:
-            logger.warning("Tried to cache step %s despite being marked as uncacheable.", step.name)
-
-    def __contains__(self, step: object):
-        if isinstance(step, Step):
-            return step.unique_id in self.cache
-        else:
-            return False
-
-    def __len__(self) -> int:
-        return len(self.cache)
-
-
-default_step_cache = MemoryStepCache()
-
-
-@StepCache.register("local")
-class LocalStepCache(StepCache):
-    """
-    This is a :class:`StepCache` that stores its results on disk, in the location given in ``dir``.
-
-    Every cached step gets a directory under ``dir`` with that step's :attr:`~tango.step.Step.unique_id`.
-    In that directory we store the results themselves in some format according to the step's
-    :attr:`~tango.step.Step.FORMAT`, and we also write a ``cache-metadata.json`` file that
-    stores the :class:`CacheMetadata`.
-
-    The presence of ``cache-metadata.json`` signifies that the cache entry is complete and
-    has been written successfully.
-
-    .. tip::
-        Registered as :class:`StepCache` under the name "local".
-
-    """
-
-    LRU_CACHE_MAX_SIZE = 8
-
-    def __init__(self, dir: PathOrStr):
-        self.dir = Path(dir)
-        self.dir.mkdir(parents=True, exist_ok=True)
-
-        # We keep an in-memory cache as well so we don't have to de-serialize stuff
-        # we happen to have in memory already.
-        self.weak_cache: MutableMapping[str, Any] = weakref.WeakValueDictionary()
-
-        # Not all Python objects can be referenced weakly, and even if they can they
-        # might get removed too quickly, so we also keep an LRU cache.
-        self.strong_cache: OrderedDict[str, Any] = collections.OrderedDict()
-
-    def _add_to_cache(self, key: str, o: Any) -> None:
-        if hasattr(o, "__next__"):
-            # We never cache iterators, because they are mutable, storing their current position.
-            return
-
-        self.strong_cache[key] = o
-        self.strong_cache.move_to_end(key)
-        while len(self.strong_cache) > self.LRU_CACHE_MAX_SIZE:
-            del self.strong_cache[next(iter(self.strong_cache))]
-
-        try:
-            self.weak_cache[key] = o
-        except TypeError:
-            pass  # Many native Python objects cannot be referenced weakly, and they throw TypeError when you try
-
-    def _get_from_cache(self, key: str) -> Optional[Any]:
-        result = self.strong_cache.get(key)
-        if result is not None:
-            self.strong_cache.move_to_end(key)
-            return result
-        try:
-            return self.weak_cache[key]
-        except KeyError:
-            return None
-
-    def __contains__(self, step: object) -> bool:
-        if isinstance(step, Step) and step.cache_results:
-            key = step.unique_id
-            if key in self.strong_cache:
-                return True
-            if key in self.weak_cache:
-                return True
-            metadata_file = self.step_dir(step) / "cache-metadata.json"
-            return metadata_file.exists()
-        else:
-            return False
-
-    def __getitem__(self, step: Step) -> Any:
-        key = step.unique_id
-        result = self._get_from_cache(key)
-        if result is None:
-            if step not in self:
-                raise KeyError(step)
-            result = step.format.read(self.step_dir(step))
-            self._add_to_cache(key, result)
-        return result
-
-    def __setitem__(self, step: Step, value: Any) -> None:
-        if not step.cache_results:
-            logger.warning("Tried to cache step %s despite being marked as uncacheable.", step.name)
-            return
-
-        location = self.step_dir(step)
-        location.mkdir(parents=True, exist_ok=True)
-
-        metadata_location = location / "cache-metadata.json"
-        if metadata_location.exists():
-            raise ValueError(f"{metadata_location} already exists! Will not overwrite.")
-        temp_metadata_location = metadata_location.with_suffix(".temp")
-
-        try:
-            step.format.write(value, location)
-            metadata = CacheMetadata(step=step.unique_id)
-            metadata.to_params().to_file(temp_metadata_location)
-            self._add_to_cache(step.unique_id, value)
-            temp_metadata_location.rename(metadata_location)
-        except:  # noqa: E722
-            try:
-                temp_metadata_location.unlink()
-            except FileNotFoundError:
-                pass
-            raise
-
-    def __len__(self) -> int:
-        return sum(1 for _ in self.dir.glob("*/cache-metadata.json"))
-
-    def step_dir(self, step_or_unique_id: Union[Step, str]) -> Path:
-        """Returns the directory that contains the results of the step.
-
-        You can use this even for a step that's not cached yet. In that case it will return the directory where
-        the results will be written."""
-        if isinstance(step_or_unique_id, Step):
-            if not step_or_unique_id.cache_results:
-                raise RuntimeError(
-                    f"Uncacheable steps (like '{step_or_unique_id.name}') don't have step directories."
-                )
-            unique_id = step_or_unique_id.unique_id
-        else:
-            unique_id = step_or_unique_id
-        return self.dir / unique_id
 
 
 @dataclass

--- a/tango/step_caches/__init__.py
+++ b/tango/step_caches/__init__.py
@@ -1,0 +1,6 @@
+"""
+Built-in :class:`~tango.step_cache.StepCache` implementations.
+"""
+
+from .local_step_cache import LocalStepCache
+from .memory_step_cache import MemoryStepCache, default_step_cache

--- a/tango/step_caches/local_step_cache.py
+++ b/tango/step_caches/local_step_cache.py
@@ -1,0 +1,135 @@
+import collections
+import logging
+import weakref
+from pathlib import Path
+from typing import Any, MutableMapping, Optional, OrderedDict, Union
+
+from tango.common.aliases import PathOrStr
+from tango.step import Step
+from tango.step_cache import CacheMetadata, StepCache
+
+logger = logging.getLogger(__name__)
+
+
+@StepCache.register("local")
+class LocalStepCache(StepCache):
+    """
+    This is a :class:`.StepCache` that stores its results on disk, in the location given in ``dir``.
+
+    Every cached step gets a directory under ``dir`` with that step's :attr:`~tango.step.Step.unique_id`.
+    In that directory we store the results themselves in some format according to the step's
+    :attr:`~tango.step.Step.FORMAT`, and we also write a ``cache-metadata.json`` file that
+    stores the :class:`.CacheMetadata`.
+
+    The presence of ``cache-metadata.json`` signifies that the cache entry is complete and
+    has been written successfully.
+
+    .. tip::
+        Registered as :class:`.StepCache` under the name "local".
+
+    """
+
+    LRU_CACHE_MAX_SIZE = 8
+
+    def __init__(self, dir: PathOrStr):
+        self.dir = Path(dir)
+        self.dir.mkdir(parents=True, exist_ok=True)
+
+        # We keep an in-memory cache as well so we don't have to de-serialize stuff
+        # we happen to have in memory already.
+        self.weak_cache: MutableMapping[str, Any] = weakref.WeakValueDictionary()
+
+        # Not all Python objects can be referenced weakly, and even if they can they
+        # might get removed too quickly, so we also keep an LRU cache.
+        self.strong_cache: OrderedDict[str, Any] = collections.OrderedDict()
+
+    def _add_to_cache(self, key: str, o: Any) -> None:
+        if hasattr(o, "__next__"):
+            # We never cache iterators, because they are mutable, storing their current position.
+            return
+
+        self.strong_cache[key] = o
+        self.strong_cache.move_to_end(key)
+        while len(self.strong_cache) > self.LRU_CACHE_MAX_SIZE:
+            del self.strong_cache[next(iter(self.strong_cache))]
+
+        try:
+            self.weak_cache[key] = o
+        except TypeError:
+            pass  # Many native Python objects cannot be referenced weakly, and they throw TypeError when you try
+
+    def _get_from_cache(self, key: str) -> Optional[Any]:
+        result = self.strong_cache.get(key)
+        if result is not None:
+            self.strong_cache.move_to_end(key)
+            return result
+        try:
+            return self.weak_cache[key]
+        except KeyError:
+            return None
+
+    def __contains__(self, step: object) -> bool:
+        if isinstance(step, Step) and step.cache_results:
+            key = step.unique_id
+            if key in self.strong_cache:
+                return True
+            if key in self.weak_cache:
+                return True
+            metadata_file = self.step_dir(step) / "cache-metadata.json"
+            return metadata_file.exists()
+        else:
+            return False
+
+    def __getitem__(self, step: Step) -> Any:
+        key = step.unique_id
+        result = self._get_from_cache(key)
+        if result is None:
+            if step not in self:
+                raise KeyError(step)
+            result = step.format.read(self.step_dir(step))
+            self._add_to_cache(key, result)
+        return result
+
+    def __setitem__(self, step: Step, value: Any) -> None:
+        if not step.cache_results:
+            logger.warning("Tried to cache step %s despite being marked as uncacheable.", step.name)
+            return
+
+        location = self.step_dir(step)
+        location.mkdir(parents=True, exist_ok=True)
+
+        metadata_location = location / "cache-metadata.json"
+        if metadata_location.exists():
+            raise ValueError(f"{metadata_location} already exists! Will not overwrite.")
+        temp_metadata_location = metadata_location.with_suffix(".temp")
+
+        try:
+            step.format.write(value, location)
+            metadata = CacheMetadata(step=step.unique_id)
+            metadata.to_params().to_file(temp_metadata_location)
+            self._add_to_cache(step.unique_id, value)
+            temp_metadata_location.rename(metadata_location)
+        except:  # noqa: E722
+            try:
+                temp_metadata_location.unlink()
+            except FileNotFoundError:
+                pass
+            raise
+
+    def __len__(self) -> int:
+        return sum(1 for _ in self.dir.glob("*/cache-metadata.json"))
+
+    def step_dir(self, step_or_unique_id: Union[Step, str]) -> Path:
+        """Returns the directory that contains the results of the step.
+
+        You can use this even for a step that's not cached yet. In that case it will return the directory where
+        the results will be written."""
+        if isinstance(step_or_unique_id, Step):
+            if not step_or_unique_id.cache_results:
+                raise RuntimeError(
+                    f"Uncacheable steps (like '{step_or_unique_id.name}') don't have step directories."
+                )
+            unique_id = step_or_unique_id.unique_id
+        else:
+            unique_id = step_or_unique_id
+        return self.dir / unique_id

--- a/tango/step_caches/memory_step_cache.py
+++ b/tango/step_caches/memory_step_cache.py
@@ -1,0 +1,43 @@
+import logging
+from typing import Any, Dict
+
+from tango.step import Step
+from tango.step_cache import StepCache
+
+logger = logging.getLogger(__name__)
+
+
+@StepCache.register("memory")
+class MemoryStepCache(StepCache):
+    """
+    This is a :class:`.StepCache` that stores results in memory. It is little more than a Python dictionary.
+
+    .. tip::
+        Registered as :class:`.StepCache` under the name "memory".
+    """
+
+    def __init__(self):
+        self.cache: Dict[str, Any] = {}
+
+    def __getitem__(self, step: Step) -> Any:
+        return self.cache[step.unique_id]
+
+    def __setitem__(self, step: Step, value: Any) -> None:
+        if step in self:
+            raise ValueError(f"{step.unique_id} is already cached! Will not overwrite.")
+        if step.cache_results:
+            self.cache[step.unique_id] = value
+        else:
+            logger.warning("Tried to cache step %s despite being marked as uncacheable.", step.name)
+
+    def __contains__(self, step: object):
+        if isinstance(step, Step):
+            return step.unique_id in self.cache
+        else:
+            return False
+
+    def __len__(self) -> int:
+        return len(self.cache)
+
+
+default_step_cache = MemoryStepCache()

--- a/tango/workspace.py
+++ b/tango/workspace.py
@@ -223,7 +223,7 @@ class Workspace(Registrable):
         would give you a :class:`~tango.workspaces.LocalWorkspace` in the directory ``/tmp/workspace``.
         """
         parsed = urlparse(url)
-        workspace_type = parsed.scheme
+        workspace_type = parsed.scheme or "local"
         workspace_cls = cast(Workspace, cls.by_name(workspace_type))
         return workspace_cls.from_parsed_url(parsed)
 

--- a/tango/workspace.py
+++ b/tango/workspace.py
@@ -12,7 +12,19 @@ from datetime import datetime, timedelta
 from enum import Enum
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Any, Dict, Iterable, List, Optional, Set, TypeVar, Union, cast
+from typing import (
+    Any,
+    ContextManager,
+    Dict,
+    Generator,
+    Iterable,
+    List,
+    Optional,
+    Set,
+    TypeVar,
+    Union,
+    cast,
+)
 from urllib.parse import ParseResult, urlparse
 
 import dill
@@ -334,14 +346,35 @@ class Workspace(Registrable):
         """
         raise NotImplementedError()
 
-    @contextmanager
-    def capture_logs_for_run(self, name: str):
+    def capture_logs_for_run(self, name: str) -> ContextManager[None]:
         """
         Should return a context manager that can be used to capture the logs for a run.
 
         By default, this doesn't do anything.
+
+        Examples
+        --------
+
+        The :class:`.LocalWorkspace` implementation uses this method to capture logs
+        to a file in the workspace's directory using the :func:`~tango.common.logging.file_handler()`
+        context manager, similar to this:
+
+        .. testcode::
+
+            from tango.common.logging import file_handler
+            from tango.workspace import Workspace
+
+            class MyLocalWorkspace(Workspace):
+                def capture_logs_for_run(self, name: str):
+                    return file_handler("/path/to/workspace/" + name + ".log")
+
         """
-        yield None
+
+        @contextmanager
+        def do_nothing() -> Generator[None, None, None]:
+            yield None
+
+        return do_nothing()
 
 
 @dataclass

--- a/tango/workspaces/__init__.py
+++ b/tango/workspaces/__init__.py
@@ -1,0 +1,6 @@
+"""
+Built-in :class:`~tango.workspace.Workspace` implementations.
+"""
+
+from .local_workspace import LocalWorkspace
+from .memory_workspace import MemoryWorkspace, default_workspace

--- a/tango/workspaces/local_workspace.py
+++ b/tango/workspaces/local_workspace.py
@@ -11,7 +11,7 @@ from sqlitedict import SqliteDict
 
 from tango.common import PathOrStr
 from tango.common.file_lock import FileLock
-from tango.common.logging import with_file_handler
+from tango.common.logging import file_handler
 from tango.common.util import exception_to_string
 from tango.step import Step
 from tango.step_cache import StepCache
@@ -441,4 +441,4 @@ class LocalWorkspace(Workspace):
         return self.runs_dir / name
 
     def capture_logs_for_run(self, name: str):
-        return with_file_handler(self.run_dir(name) / "out.log")
+        return file_handler(self.run_dir(name) / "out.log")

--- a/tango/workspaces/local_workspace.py
+++ b/tango/workspaces/local_workspace.py
@@ -14,7 +14,8 @@ from tango.common.file_lock import FileLock
 from tango.common.logging import with_file_handler
 from tango.common.util import exception_to_string
 from tango.step import Step
-from tango.step_cache import LocalStepCache, StepCache
+from tango.step_cache import StepCache
+from tango.step_caches import LocalStepCache
 from tango.workspace import Run, StepExecutionMetadata, StepInfo, StepState, Workspace
 
 logger = logging.getLogger(__name__)

--- a/tango/workspaces/local_workspace.py
+++ b/tango/workspaces/local_workspace.py
@@ -1,12 +1,6 @@
-import getpass
 import json
 import logging
 import os
-import platform
-import socket
-import sys
-import time
-from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, Iterable, Iterator, Optional, Set, TypeVar, Union
@@ -15,214 +9,17 @@ from urllib.parse import ParseResult
 import petname
 from sqlitedict import SqliteDict
 
-from tango.common import FromParams, PathOrStr
+from tango.common import PathOrStr
 from tango.common.file_lock import FileLock
 from tango.common.logging import with_file_handler
 from tango.common.util import exception_to_string
 from tango.step import Step
 from tango.step_cache import LocalStepCache, StepCache
-from tango.version import VERSION
-from tango.workspace import Run, StepInfo, StepState, Workspace
+from tango.workspace import Run, StepExecutionMetadata, StepInfo, StepState, Workspace
 
 logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
-
-
-@dataclass
-class PlatformMetadata(FromParams):
-    python: str = field(default_factory=platform.python_version)
-    """
-    The Python version.
-    """
-
-    operating_system: str = field(default_factory=platform.platform)
-    """
-    Full operating system name.
-    """
-
-    executable: Path = field(default_factory=lambda: Path(sys.executable))
-    """
-    Path to the Python executable.
-    """
-
-    cpu_count: Optional[int] = field(default_factory=os.cpu_count)
-    """
-    Numbers of CPUs on the machine.
-    """
-
-    user: str = field(default_factory=getpass.getuser)
-    """
-    The user that ran this step.
-    """
-
-    host: str = field(default_factory=socket.gethostname)
-    """
-    Name of the host machine.
-    """
-
-    root: Path = field(default_factory=lambda: Path(os.getcwd()))
-    """
-    The root directory from where the Python executable was ran.
-    """
-
-
-@dataclass
-class GitMetadata(FromParams):
-    commit: Optional[str] = None
-    """
-    The commit SHA of the current repo.
-    """
-
-    remote: Optional[str] = None
-    """
-    The URL of the primary remote.
-    """
-
-    @classmethod
-    def check_for_repo(cls) -> Optional["GitMetadata"]:
-        import subprocess
-
-        try:
-            commit = (
-                subprocess.check_output("git rev-parse HEAD".split(" "), stderr=subprocess.DEVNULL)
-                .decode("ascii")
-                .strip()
-            )
-            remote: Optional[str] = None
-            for line in (
-                subprocess.check_output("git remote -v".split(" "))
-                .decode("ascii")
-                .strip()
-                .split("\n")
-            ):
-                if "(fetch)" in line:
-                    _, line = line.split("\t")
-                    remote = line.split(" ")[0]
-                    break
-            return cls(commit=commit, remote=remote)
-        except (subprocess.CalledProcessError, FileNotFoundError):
-            return None
-
-
-@dataclass
-class TangoMetadata(FromParams):
-    version: str = VERSION
-    """
-    The tango release version.
-    """
-
-    command: str = field(default_factory=lambda: " ".join(sys.argv))
-    """
-    The exact command used.
-    """
-
-
-@dataclass
-class StepExecutionMetadata(FromParams):
-    step: str
-    """
-    The unique ID of the step.
-    """
-
-    config: Optional[Dict[str, Any]] = None
-    """
-    The raw config of the step.
-    """
-
-    platform: PlatformMetadata = field(default_factory=PlatformMetadata)
-    """
-    The :class:`PlatformMetadata`.
-    """
-
-    git: Optional[GitMetadata] = field(default_factory=GitMetadata.check_for_repo)
-    """
-    The :class:`GitMetadata`.
-    """
-
-    tango: Optional[TangoMetadata] = field(default_factory=TangoMetadata)
-    """
-    The :class:`TangoMetadata`.
-    """
-
-    started_at: float = field(default_factory=time.time)
-    """
-    The unix timestamp from when the run was started.
-    """
-
-    finished_at: Optional[float] = None
-    """
-    The unix timestamp from when the run finished.
-    """
-
-    duration: Optional[float] = None
-    """
-    The number of seconds the step ran for.
-    """
-
-    def _save_pip(self, run_dir: Path):
-        """
-        Saves the current working set of pip packages to ``run_dir``.
-        """
-        # Adapted from the Weights & Biases client library:
-        # github.com/wandb/client/blob/a04722575eee72eece7eef0419d0cea20940f9fe/wandb/sdk/internal/meta.py#L56-L72
-        try:
-            import pkg_resources
-
-            installed_packages = [d for d in iter(pkg_resources.working_set)]
-            installed_packages_list = sorted(
-                ["%s==%s" % (i.key, i.version) for i in installed_packages]
-            )
-            with (run_dir / "requirements.txt").open("w") as f:
-                f.write("\n".join(installed_packages_list))
-        except Exception as exc:
-            logger.exception("Error saving pip packages: %s", exc)
-
-    def _save_conda(self, run_dir: Path):
-        """
-        Saves the current conda environment to ``run_dir``.
-        """
-        # Adapted from the Weights & Biases client library:
-        # github.com/wandb/client/blob/a04722575eee72eece7eef0419d0cea20940f9fe/wandb/sdk/internal/meta.py#L74-L87
-        current_shell_is_conda = os.path.exists(os.path.join(sys.prefix, "conda-meta"))
-        if current_shell_is_conda:
-            import subprocess
-
-            try:
-                result = subprocess.run(["conda", "env", "export"], capture_output=True)
-                if (
-                    result.returncode != 0
-                    and result.stderr is not None
-                    and "Unable to determine environment" in result.stderr.decode()
-                ):
-                    result = subprocess.run(
-                        ["conda", "env", "export", "-n", "base"], capture_output=True
-                    )
-
-                if result.returncode != 0:
-                    if result.stderr is not None:
-                        logger.exception("Error saving conda packages: %s", result.stderr.decode())
-                    else:
-                        result.check_returncode()
-                elif result.stdout is not None:
-                    with (run_dir / "conda-environment.yaml").open("w") as f:
-                        f.write(result.stdout.decode())
-            except Exception as exc:
-                logger.exception("Error saving conda packages: %s", exc)
-
-    def save(self, run_dir: Path):
-        """
-        Should be called after the run has finished to save to file.
-        """
-        self.finished_at = time.time()
-        self.duration = round(self.finished_at - self.started_at, 4)
-
-        # Save pip dependencies and conda environment files.
-        self._save_pip(run_dir)
-        self._save_conda(run_dir)
-
-        # Serialize self.
-        self.to_params().to_file(run_dir / "execution-metadata.json")
 
 
 @Workspace.register("local")

--- a/tango/workspaces/memory_workspace.py
+++ b/tango/workspaces/memory_workspace.py
@@ -1,0 +1,135 @@
+import copy
+from datetime import datetime
+from typing import Dict, Iterable, Iterator, Optional, TypeVar, Union
+from urllib.parse import ParseResult
+
+import petname
+
+from tango import step_cache
+from tango.common.util import exception_to_string
+from tango.step import Step
+from tango.step_cache import StepCache
+from tango.workspace import Run, StepInfo, StepState, Workspace
+
+T = TypeVar("T")
+
+
+@Workspace.register("memory")
+class MemoryWorkspace(Workspace):
+    """
+    This is a workspace that keeps all its data in memory. This is useful for debugging or for quick jobs, but of
+    course you don't get any caching across restarts.
+
+    .. tip::
+
+        Registered as a :class:`~tango.workspace.Workspace` under the name "memory".
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.unique_id_to_info: Dict[str, StepInfo] = {}
+        self.runs: Dict[str, Run] = {}
+
+    @classmethod
+    def from_parsed_url(cls, parsed_url: ParseResult) -> "Workspace":
+        return cls()
+
+    @property
+    def step_cache(self) -> StepCache:
+        return step_cache.default_step_cache
+
+    def step_info(self, step_or_unique_id: Union[Step, str]) -> StepInfo:
+        unique_id = (
+            step_or_unique_id.unique_id
+            if isinstance(step_or_unique_id, Step)
+            else step_or_unique_id
+        )
+        try:
+            return self.unique_id_to_info[unique_id]
+        except KeyError:
+            if isinstance(step_or_unique_id, Step):
+                step = step_or_unique_id
+                return StepInfo(
+                    step.unique_id,
+                    step.name if step.name != step.unique_id else None,
+                    step.__class__.__name__,
+                    step.VERSION,
+                    {dep.unique_id for dep in step.dependencies},
+                    step.cache_results,
+                )
+            else:
+                raise KeyError()
+
+    def step_starting(self, step: Step) -> None:
+        # We don't do anything with uncacheable steps.
+        if not step.cache_results:
+            return
+
+        self.unique_id_to_info[step.unique_id] = StepInfo(
+            step.unique_id,
+            step.name if step.name != step.unique_id else None,
+            step.__class__.__name__,
+            step.VERSION,
+            {dep.unique_id for dep in step.dependencies},
+            step.cache_results,
+            datetime.now(),
+        )
+
+    def step_finished(self, step: Step, result: T) -> T:
+        # We don't do anything with uncacheable steps.
+        if not step.cache_results:
+            return result
+
+        existing_step_info = self.unique_id_to_info[step.unique_id]
+        if existing_step_info.state != StepState.RUNNING:
+            raise RuntimeError(f"Step {step.name} is ending, but it never started.")
+        existing_step_info.end_time = datetime.now()
+
+        if step.cache_results:
+            self.step_cache[step] = result
+            if hasattr(result, "__next__"):
+                assert isinstance(result, Iterator)
+                # Caching the iterator will consume it, so we write it to the cache and then read from the cache
+                # for the return value.
+                return self.step_cache[step]
+        return result
+
+    def step_failed(self, step: Step, e: BaseException) -> None:
+        # We don't do anything with uncacheable steps.
+        if not step.cache_results:
+            return
+
+        assert e is not None
+        existing_step_info = self.unique_id_to_info[step.unique_id]
+        if existing_step_info.state != StepState.RUNNING:
+            raise RuntimeError(f"Step {step.name} is failing, but it never started.")
+        existing_step_info.end_time = datetime.now()
+        existing_step_info.error = exception_to_string(e)
+
+    def register_run(self, targets: Iterable[Step], name: Optional[str] = None) -> Run:
+        if name is None:
+            name = petname.generate()
+        steps: Dict[str, StepInfo] = {}
+        for step in targets:
+            step_info = StepInfo(
+                step.unique_id,
+                step.name if step.name != step.unique_id else None,
+                step.__class__.__name__,
+                step.VERSION,
+                {dep.unique_id for dep in step.dependencies},
+                step.cache_results,
+            )
+            self.unique_id_to_info[step.unique_id] = step_info
+            steps[step.unique_id] = step_info
+        run = Run(name, steps, datetime.now())
+        self.runs[name] = run
+        return run
+
+    def registered_runs(self) -> Dict[str, Run]:
+        return copy.deepcopy(self.runs)
+
+    def registered_run(self, name: str) -> Run:
+        return copy.deepcopy(self.runs[name])
+
+
+default_workspace = MemoryWorkspace()

--- a/tango/workspaces/memory_workspace.py
+++ b/tango/workspaces/memory_workspace.py
@@ -5,10 +5,10 @@ from urllib.parse import ParseResult
 
 import petname
 
-from tango import step_cache
 from tango.common.util import exception_to_string
 from tango.step import Step
 from tango.step_cache import StepCache
+from tango.step_caches import default_step_cache
 from tango.workspace import Run, StepInfo, StepState, Workspace
 
 T = TypeVar("T")
@@ -36,7 +36,7 @@ class MemoryWorkspace(Workspace):
 
     @property
     def step_cache(self) -> StepCache:
-        return step_cache.default_step_cache
+        return default_step_cache
 
     def step_info(self, step_or_unique_id: Union[Step, str]) -> StepInfo:
         unique_id = (

--- a/tests/executor_test.py
+++ b/tests/executor_test.py
@@ -3,8 +3,9 @@ from pathlib import Path
 from tango.common.params import Params
 from tango.common.testing import TangoTestCase
 from tango.executor import Executor
-from tango.local_workspace import LocalWorkspace, StepExecutionMetadata
 from tango.step import Step
+from tango.workspace import StepExecutionMetadata
+from tango.workspaces import LocalWorkspace
 
 
 class AdditionStep(Step):

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -9,8 +9,8 @@ import pytest
 
 from tango.common import Params
 from tango.common.testing import TangoTestCase
-from tango.local_workspace import StepExecutionMetadata
 from tango.version import VERSION
+from tango.workspace import StepExecutionMetadata
 
 
 class TestMain(TangoTestCase):

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -112,6 +112,30 @@ class TestMain(TangoTestCase):
         # We should see two runs now.
         assert len(os.listdir(self.TEST_DIR / "runs")) == 2
 
+    def test_experiment_with_memory_workspace(self):
+        cmd = [
+            "tango",
+            "run",
+            str(self.FIXTURES_ROOT / "experiment" / "hello_world.jsonnet"),
+            "-i",
+            "test_fixtures.package",
+            "-w",
+            "memory://",
+        ]
+        result = subprocess.run(cmd, capture_output=True)
+        assert result.returncode == 0
+
+    def test_experiment_with_default_workspace(self):
+        cmd = [
+            "tango",
+            "run",
+            str(self.FIXTURES_ROOT / "experiment" / "hello_world.jsonnet"),
+            "-i",
+            "test_fixtures.package",
+        ]
+        result = subprocess.run(cmd, capture_output=True)
+        assert result.returncode == 0
+
     def test_random_experiment(self):
         cmd = [
             "tango",

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -72,7 +72,7 @@ class TestMain(TangoTestCase):
             str(self.FIXTURES_ROOT / "experiment" / "hello_world.jsonnet"),
             "-i",
             "test_fixtures.package",
-            "-d",
+            "-w",
             str(self.TEST_DIR),
         ]
         result = subprocess.run(cmd, capture_output=True)
@@ -143,7 +143,7 @@ class TestMain(TangoTestCase):
             str(self.FIXTURES_ROOT / "experiment" / "random.jsonnet"),
             "-i",
             "test_fixtures.package",
-            "-d",
+            "-w",
             str(self.TEST_DIR),
         ]
         result = subprocess.run(cmd)
@@ -166,7 +166,7 @@ class TestMain(TangoTestCase):
                 str(self.FIXTURES_ROOT / "experiment" / "multiprocessing.jsonnet"),
                 "-i",
                 "test_fixtures.package",
-                "-d",
+                "-w",
                 str(self.TEST_DIR),
             ]
         )

--- a/tests/workspaces/local_workspace_test.py
+++ b/tests/workspaces/local_workspace_test.py
@@ -2,9 +2,10 @@ from shutil import copytree
 
 import pytest
 
-from tango import LocalWorkspace, Step
+from tango import Step
 from tango.common.testing import TangoTestCase
 from tango.workspace import StepState
+from tango.workspaces import LocalWorkspace
 
 
 class AdditionStep(Step):


### PR DESCRIPTION
This is the first pull request for the [Tango remote execution and workspaces](https://docs.google.com/document/d/1HkZW32Gn9AocMIGpNvUMp3qus8aJjW7k8Nt1F_5AXFM/edit#heading=h.83mquxrqsg59) project.

This PR contains minor API and internal module organization changes to prepare for the addition of remote workspaces. I've tried hard to keep the commit history clean to make reviewing this PR easier, so I'd recommend reviewing this one commit at a time:
- [Allow Workspace configuration from 'tango run'](https://github.com/allenai/tango/pull/201/commits/5237adcd58f764f0357ec9d11dc1216a22e71a04)
  - Basically this makes it so users can actually use different `Workspace` implementations from `tango run`.
  - It adds a `Workspace.from_url()` method and a command-line option (for `tango run`) called `-w/--workspace` that takes a workspace url like "local:///tmp/workspace".
  - Also lets users specify a default workspace in their `tango.yml` configuration file so they don't always have to pass `-d/--workspace-dir` or `-w/--workspace`.
- [move Workspace implementations to their own submodule 'tango.workspaces'](https://github.com/allenai/tango/pull/201/commits/421f6a2f7935bf5e90942ea265e3c9a5fea66d06)
  - This is simply an update to internal module organization. Previously we had the modules `tango.workspace`, which included the base class and also the `MemoryWorkspace` implementation, and then `tango.local_workspace`, which had the `LocalWorkspace` implementation. This "flat" module structure is not consisted with how we usually organize things and doesn't "scale" well to adding new `Workspace` implementations. So I created a new submodule `tango.workspaces` and put both implementations (`MemoryWorkspace` and `LocalWorkspace`) in there.
  - I also moved the `StepExecutionMetadata` (and related classes) to `tango.workspace`, since I think this will be used by other `Workspace` implementations in the future, not just `LocalWorkspace`.
- [move StepCache implementations to their own submodule 'tango.step_caches'](https://github.com/allenai/tango/pull/201/commits/715475fb059e6a738c8b58828ae91d308561d0c2)
  - This is just another update to internal module organization, similar to the above, but for `StepCache` and its implementations. It creates a new submodule `tango.step_caches` and puts `MemoryStepCache` and `LocalStepCache` in there.
 - [deprecate -d/--workspace-dir, allow -w to take a path](https://github.com/allenai/tango/pull/201/commits/2357eae3615ba4e6ce8c080ee3b4c2dfde5d9e17)
   - The `-d/--workspace-dir` option is now deprecated. When someone uses that option, we issue a deprecation warning with a suggestion to use `-w/--workspace` instead.
   - The `-w/--workspace` option also take a raw path, like `/tmp/workspace`, which is equivalent to `local:///tmp/workspace`. This is for convenience so users can benefit from path completion on the command line.