### PR TITLE
Allow setting environment variables in tango settings, fix bug with TANGO_LOG_LEVEL env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   on dual k80 GPUs via Beaker.
 - Added the "-w/--workspace" option to `tango run` and `tango server` commands. This option takes a path or URL, and instantiates the workspace from the URL using the newly added `Workspace.from_url()` method.
 - Added the "workspace" field to `TangoGlobalSettings`.
+- Added the "environment" field to `TangoGlobalSettings` for setting environment variables each
+  time `tango` is run.
 - Added a utility function to get a `StepGraph` directly from a file.
 - Added `tango.settings` module and `tango settings` group of commands.
 - A format for storing sequences as `SqliteSparseSequence`.
@@ -31,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed a small bug `LocalWorkspace` would fail to capture the conda environment in our Docker image.
 - Fixed activation of `FILE_FRIENDLY_LOGGING` when set from the corresponding environment variable.
+- Fixed setting log level via the environment variable `TANGO_LOG_LEVEL`.
 - Use relative paths within the `work_dir` for symbolic links to the latest and the best checkpoints in `TorchTrainStep`.
 - Fixed some scenarios where Tango can hang after finishing all steps.
 - `distributed_port` and `log_every` parameters won't factor into `TorchTrainStep`'s unique ID.

--- a/tango/__main__.py
+++ b/tango/__main__.py
@@ -150,9 +150,7 @@ def main(
         from tango.common.aliases import EnvVarNames
 
         # These environment variables should not be set this way since they'll be ignored.
-        blocked_env_variable_names = {
-            name for k, name in EnvVarNames.__dict__.items() if k.isupper()
-        }
+        blocked_env_variable_names = EnvVarNames.values()
 
         for key, value in settings.environment.items():
             if key not in blocked_env_variable_names:
@@ -563,7 +561,7 @@ def env(settings: TangoGlobalSettings, key: str, value: str) -> TangoGlobalSetti
     from tango.common.aliases import EnvVarNames
 
     # These environment variables should not be set this way since they'll be ignored.
-    blocked_env_variable_names = {name for k, name in EnvVarNames.__dict__.items() if k.isupper()}
+    blocked_env_variable_names = EnvVarNames.values()
 
     if key in blocked_env_variable_names:
         raise click.ClickException(

--- a/tango/common/aliases.py
+++ b/tango/common/aliases.py
@@ -1,12 +1,18 @@
+from enum import Enum, unique
 from os import PathLike
-from typing import Union
+from typing import Set, Union
 
 PathOrStr = Union[str, PathLike]
 
 
-class EnvVarNames:
+@unique
+class EnvVarNames(Enum):
     FILE_FRIENDLY_LOGGING_ENV_VAR = "FILE_FRIENDLY_LOGGING"
-    LOG_LEVEL_ENV_VAR: str = "TANGO_LOG_LEVEL"
-    CLICK_LOGGER_ENABLED_ENV_VAR: str = "TANGO_CLICK_LOGGER_ENABLED"
-    LOGGING_HOST_ENV_VAR: str = "TANGO_LOGGING_HOST"
-    LOGGING_PORT_ENV_VAR: str = "TANGO_LOGGING_PORT"
+    LOG_LEVEL_ENV_VAR = "TANGO_LOG_LEVEL"
+    CLICK_LOGGER_ENABLED_ENV_VAR = "TANGO_CLICK_LOGGER_ENABLED"
+    LOGGING_HOST_ENV_VAR = "TANGO_LOGGING_HOST"
+    LOGGING_PORT_ENV_VAR = "TANGO_LOGGING_PORT"
+
+    @classmethod
+    def values(cls) -> Set[str]:
+        return set(e.value for e in cls)

--- a/tango/common/aliases.py
+++ b/tango/common/aliases.py
@@ -2,3 +2,11 @@ from os import PathLike
 from typing import Union
 
 PathOrStr = Union[str, PathLike]
+
+
+class EnvVarNames:
+    FILE_FRIENDLY_LOGGING_ENV_VAR = "FILE_FRIENDLY_LOGGING"
+    LOG_LEVEL_ENV_VAR: str = "TANGO_LOG_LEVEL"
+    CLICK_LOGGER_ENABLED_ENV_VAR: str = "TANGO_CLICK_LOGGER_ENABLED"
+    LOGGING_HOST_ENV_VAR: str = "TANGO_LOGGING_HOST"
+    LOGGING_PORT_ENV_VAR: str = "TANGO_LOGGING_PORT"

--- a/tango/common/logging.py
+++ b/tango/common/logging.py
@@ -96,7 +96,7 @@ from .exceptions import SigTermReceived
 from .util import _parse_bool, _parse_optional_int
 
 FILE_FRIENDLY_LOGGING: bool = _parse_bool(
-    os.environ.get(EnvVarNames.FILE_FRIENDLY_LOGGING_ENV_VAR, False)
+    os.environ.get(EnvVarNames.FILE_FRIENDLY_LOGGING_ENV_VAR.value, False)
 )
 """
 If this flag is set to ``True``, we remove special styling characters from log messages,
@@ -119,7 +119,7 @@ For example,
 
 """
 
-TANGO_LOG_LEVEL: Optional[str] = os.environ.get(EnvVarNames.LOG_LEVEL_ENV_VAR, None)
+TANGO_LOG_LEVEL: Optional[str] = os.environ.get(EnvVarNames.LOG_LEVEL_ENV_VAR.value, None)
 """
 The log level to use globally. The value can be set from the corresponding environment variable
 (``TANGO_LOG_LEVEL``) or field in a :class:`~tango.__main__.TangoGlobalSettings` file (``log_level``),
@@ -139,7 +139,7 @@ For example,
 
 # Click logger disabled by default in case nobody calls initialize_logging().
 TANGO_CLICK_LOGGER_ENABLED: bool = _parse_bool(
-    os.environ.get(EnvVarNames.CLICK_LOGGER_ENABLED_ENV_VAR, False)
+    os.environ.get(EnvVarNames.CLICK_LOGGER_ENABLED_ENV_VAR.value, False)
 )
 
 
@@ -280,9 +280,9 @@ class LogRecordSocketReceiver(socketserver.ThreadingTCPServer):
                 self.handle_request()
 
 
-_LOGGING_HOST: str = os.environ.get(EnvVarNames.LOGGING_HOST_ENV_VAR, "localhost")
+_LOGGING_HOST: str = os.environ.get(EnvVarNames.LOGGING_HOST_ENV_VAR.value, "localhost")
 _LOGGING_PORT: Optional[int] = _parse_optional_int(
-    os.environ.get(EnvVarNames.LOGGING_PORT_ENV_VAR, None)
+    os.environ.get(EnvVarNames.LOGGING_PORT_ENV_VAR.value, None)
 )
 _LOGGING_SERVER: Optional[LogRecordSocketReceiver] = None
 _LOGGING_SERVER_THREAD: Optional[threading.Thread] = None
@@ -401,13 +401,15 @@ def _initialize_logging(
     # so that child processes can read the environment variables to determine the right
     # settings.
     TANGO_LOG_LEVEL = log_level
-    os.environ[EnvVarNames.LOG_LEVEL_ENV_VAR] = log_level
+    os.environ[EnvVarNames.LOG_LEVEL_ENV_VAR.value] = log_level
     if file_friendly_logging is not None:
         FILE_FRIENDLY_LOGGING = file_friendly_logging
-        os.environ[EnvVarNames.FILE_FRIENDLY_LOGGING_ENV_VAR] = str(file_friendly_logging).lower()
+        os.environ[EnvVarNames.FILE_FRIENDLY_LOGGING_ENV_VAR.value] = str(
+            file_friendly_logging
+        ).lower()
     if enable_click_logs is not None:
         TANGO_CLICK_LOGGER_ENABLED = enable_click_logs
-        os.environ[EnvVarNames.CLICK_LOGGER_ENABLED_ENV_VAR] = str(enable_click_logs).lower()
+        os.environ[EnvVarNames.CLICK_LOGGER_ENABLED_ENV_VAR.value] = str(enable_click_logs).lower()
 
     from .tqdm import logger as tqdm_logger
 
@@ -449,7 +451,7 @@ def _initialize_logging(
         # https://docs.python.org/3.7/howto/logging-cookbook.html#sending-and-receiving-logging-events-across-a-network
         _LOGGING_SERVER = LogRecordSocketReceiver(_LOGGING_HOST, 0)
         _LOGGING_PORT = _LOGGING_SERVER.server_address[1]
-        os.environ[EnvVarNames.LOGGING_PORT_ENV_VAR] = str(_LOGGING_PORT)
+        os.environ[EnvVarNames.LOGGING_PORT_ENV_VAR.value] = str(_LOGGING_PORT)
         _LOGGING_SERVER_THREAD = threading.Thread(
             target=_LOGGING_SERVER.serve_until_stopped, daemon=True
         )

--- a/tango/format.py
+++ b/tango/format.py
@@ -5,7 +5,6 @@ import importlib
 import json
 import logging
 import lzma
-import pathlib
 from abc import abstractmethod
 from os import PathLike
 from pathlib import Path
@@ -409,7 +408,7 @@ class SqliteSequenceFormat(Format[Sequence[T]]):
     FILENAME = "data.sqlite"
 
     def write(self, artifact: Sequence[T], dir: Union[str, PathLike]):
-        dir = pathlib.Path(dir)
+        dir = Path(dir)
         try:
             (dir / self.FILENAME).unlink()
         except FileNotFoundError:
@@ -421,7 +420,7 @@ class SqliteSequenceFormat(Format[Sequence[T]]):
             sqlite.extend(artifact)
 
     def read(self, dir: Union[str, PathLike]) -> Sequence[T]:
-        dir = pathlib.Path(dir)
+        dir = Path(dir)
         return SqliteSparseSequence(dir / self.FILENAME, read_only=True)
 
 
@@ -480,7 +479,7 @@ class SqliteDictFormat(Format[DatasetDict]):
     VERSION = 3
 
     def write(self, artifact: DatasetDict, dir: Union[str, PathLike]):
-        dir = pathlib.Path(dir)
+        dir = Path(dir)
         with gzip.open(dir / "metadata.dill.gz", "wb") as f:
             dill.dump(artifact.metadata, f)
         for split_name, split in artifact.splits.items():
@@ -498,7 +497,7 @@ class SqliteDictFormat(Format[DatasetDict]):
                 sqlite.extend(split)
 
     def read(self, dir: Union[str, PathLike]) -> DatasetDict:
-        dir = pathlib.Path(dir)
+        dir = Path(dir)
         with gzip.open(dir / "metadata.dill.gz", "rb") as f:
             metadata = dill.load(f)
         splits = {

--- a/tango/settings.py
+++ b/tango/settings.py
@@ -4,7 +4,9 @@ from typing import Any, ClassVar, Dict, List, Optional
 
 import yaml
 
-from tango.common import FromParams, Params, PathOrStr
+from .common.aliases import PathOrStr
+from .common.from_params import FromParams
+from .common.params import Params
 
 
 @dataclass
@@ -23,7 +25,7 @@ class TangoGlobalSettings(FromParams):
     An list of modules where custom registered steps or classes can be found.
     """
 
-    log_level: Optional[str] = "warning"
+    log_level: Optional[str] = None
     """
     The log level to use. Options are "debug", "info", "warning", and "error".
 
@@ -45,6 +47,11 @@ class TangoGlobalSettings(FromParams):
     or "forkserver". Default is "spawn".
 
     See :func:`multiprocessing.set_start_method()` for more details.
+    """
+
+    environment: Optional[Dict[str, str]] = None
+    """
+    Environment variables that will be set each time ``tango`` is run.
     """
 
     _path: Optional[Path] = None

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -217,3 +217,13 @@ class TestSettings(TangoTestCase):
         cmd = "tango settings set include-package foo".split(" ")
         with pytest.raises(subprocess.CalledProcessError):
             subprocess.run(cmd, check=True)
+
+    def test_settings_set_environment(self):
+        cmd = "tango settings set env FOO BAR".split(" ")
+        subprocess.run(cmd, check=True)
+        assert self.settings.environment == {"FOO": "BAR"}
+
+    def test_settings_set_environment_blocked_var(self):
+        cmd = "tango settings set env TANGO_LOG_LEVEL info".split(" ")
+        with pytest.raises(subprocess.CalledProcessError):
+            subprocess.run(cmd, check=True)


### PR DESCRIPTION
Adds a field `environment: Dict[str, str]` to `TangoGlobalSettings`, which is a mapping of env variables that will be added to the environment each time `tango` is run. Also adds a subcommand `tango settings set env` to add or update these variables.

I've found this helpful when working on the W&B Workspace, because there are certain W&B environment variables that I want to set when using tango, but not otherwise.

Any environment variables are allowed to be set this way EXCEPT for those that already have a corresponding field in `TangoGlobalSettings`, such as `TANGO_LOG_LEVEL` which has the corresponding settings field `log_level`. There are two reasons we should disallow setting those specific env vars that way:
1. It would lead to confusing behavior because it's not obvious which should take precedence, the env var or the settings field.
2. The global variables that take values from those environment variables (e.g. `tango.common.logging.LOG_LEVEL`) will have already been imported by the time we get to the point where we're setting those environment variables from `TangoGlobalSettings.environment`, so they would take no effect unless we refactor how we initialize those global variables.

This also fixes a bug where the `TANGO_LOG_LEVEL` env var was completely ignored.