### PR TITLE
Make current Workspace accessible from Step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Added a convenience property `.workspace` to `Step` class that can be called from a step's `.run()` method to get the current `Workspace` being used.
+
 ## [v0.6.0](https://github.com/allenai/tango/releases/tag/v0.6.0) - 2022-02-25
 
 ### Added


### PR DESCRIPTION
It would be nice if the `Step` could be aware of the workspace being used within it's `.run()` method, and if the `Workspace` could be aware of the current `Run`. This adds properties for that.

I'm finding `Step.workspace` useful in order to mesh the W&B train callback with the W&B workspace, because the former has to be aware of the latter. And I also need some way of making the workspace aware of the current `Run` when `Workspace.step_starting()` is called so my W&B workspace can record information about the run in the step's data that's logged to W&B. That's what `Workspace.current_run` is for.