### PR TITLE
Update torch version where it's hard-coded, add an automatic remind to do this stuff in the future

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,9 @@ updates:
 - package-ecosystem: pip
   directory: "/"
   schedule:
-    interval: daily
-    time: "13:00"
+    interval: "daily"
   open-pull-requests-limit: 10
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "daily"

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,5 +1,3 @@
-name: PR Checks
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -170,7 +170,7 @@ jobs:
         if: steps.virtualenv-cache.outputs.cache-hit != 'true' && (contains(matrix.task.extras, 'torch') || contains(matrix.task.extras, 'all') || matrix.task.requires_torch)
         run: |
           . .venv/bin/activate
-          pip install torch==1.10.2+cpu -f https://download.pytorch.org/whl/cpu/torch_stable.html
+          pip install torch==1.11.0+cpu -f https://download.pytorch.org/whl/cpu/torch_stable.html
 
       - name: Install editable (no cache hit)
         if: steps.virtualenv-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/update_dependency_pr.yml
+++ b/.github/workflows/update_dependency_pr.yml
@@ -1,0 +1,24 @@
+name: Update dependency PR 
+on:
+  pull_request:
+    types:
+      - opened
+    paths:
+      - 'requirements.txt'
+      - 'dev-requirements.txt'
+
+jobs:
+  torch:
+    name: torch
+    runs-on: ubuntu-latest
+    if: startsWith(github.head_ref, 'dependabot/pip/torch-')
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'Hello! This is a PyTorch upgrade, which means you will also need to update:\n- [ ] The base image in `Dockerfile`\n- [ ] The base image in `Dockerfile.test`\n- [ ] The torch version in `.github/workflows/main.yml`'
+            })

--- a/.github/workflows/update_dependency_pr.yml
+++ b/.github/workflows/update_dependency_pr.yml
@@ -1,20 +1,17 @@
 name: Update dependency PR 
 on:
   pull_request:
-    branches:
-      - main
-    # types:
-    #   - opened
-    # paths:
-    #   - 'requirements.txt'
-    #   - 'dev-requirements.txt'
+    types:
+      - opened
+    paths:
+      - 'requirements.txt'
+      - 'dev-requirements.txt'
 
 jobs:
   torch:
     name: torch
     runs-on: ubuntu-latest
-    # if: startsWith(github.head_ref, 'dependabot/pip/torch-')
-    if: startsWith(github.head_ref, 'ci-updates')
+    if: startsWith(github.head_ref, 'dependabot/pip/torch-')
     steps:
       - uses: actions/github-script@v6
         with:
@@ -23,5 +20,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: 'Hello! This is a PyTorch upgrade, which means you will also need to update:\n- [ ] The base image in `Dockerfile`\n- [ ] The base image in `Dockerfile.test`\n- [ ] The torch version in `.github/workflows/main.yml`'
+              body: 'Hello! This is a [PyTorch](https://pytorch.org/) upgrade, which means you will also need to update:\n- [ ] The base image in `Dockerfile`\n- [ ] The base image in `Dockerfile.test`\n- [ ] The torch version hard-coded in `.github/workflows/main.yml`'
             })

--- a/.github/workflows/update_dependency_pr.yml
+++ b/.github/workflows/update_dependency_pr.yml
@@ -13,7 +13,8 @@ jobs:
   torch:
     name: torch
     runs-on: ubuntu-latest
-    if: startsWith(github.head_ref, 'dependabot/pip/torch-')
+    # if: startsWith(github.head_ref, 'dependabot/pip/torch-')
+    if: startsWith(github.head_ref, 'ci-updates')
     steps:
       - uses: actions/github-script@v6
         with:

--- a/.github/workflows/update_dependency_pr.yml
+++ b/.github/workflows/update_dependency_pr.yml
@@ -1,11 +1,13 @@
 name: Update dependency PR 
 on:
   pull_request:
-    types:
-      - opened
-    paths:
-      - 'requirements.txt'
-      - 'dev-requirements.txt'
+    branches:
+      - main
+    # types:
+    #   - opened
+    # paths:
+    #   - 'requirements.txt'
+    #   - 'dev-requirements.txt'
 
 jobs:
   torch:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a convenience property `.workspace` to `Step` class that can be called from a step's `.run()` method to get the current `Workspace` being used.
 - Gave `FromParams` objects (which includes all `Registrable` objects) the ability to version themselves.
 
+### Changed
+
+- Upgraded PyTorch version in `tango` Docker image to latest `v1.11.0+cu113`.
+
 ### Fixed
 
 - Fixed bug that mistakenly disallowed fully-qualified names containing `"_"` (underscores) in the config.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # This Dockerfile can be used to build a Docker image suitable for tango projects.
 
-ARG BASE_IMAGE=ghcr.io/allenai/pytorch:1.10.2-cuda11.3
+ARG BASE_IMAGE=ghcr.io/allenai/pytorch:1.11.0-cuda11.3
 FROM ${BASE_IMAGE}
 
 WORKDIR /stage

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -4,7 +4,7 @@
 # variable "COMMIT_SHA". That way we don't need to rebuild and push the image each time we run
 # tests, and we can be sure the dependencies are always up-to-date.
 
-FROM ghcr.io/allenai/pytorch:1.10.2-cuda11.3
+FROM ghcr.io/allenai/pytorch:1.11.0-cuda11.3
 
 COPY scripts/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh


### PR DESCRIPTION
<!-- To ensure we can review your pull request promptly please complete this template entirely. -->

<!-- Please reference the issue number here. You can replace "Fixes" with "Closes" if it makes more sense. -->
We have an issue with Dependabot upgrades for PyTorch because Dependabot is only capable of changing the version hard-coded in `requirements.txt`, yet we have to hard-code the torch version in several other places since different torch versions require different install commands depending on whether you want GPU support or not.

This PR updates the remaining hard-coded torch versions that Dependabot missed in the last PR, and also adds a GitHub Actions workflow that will automatically add [a comment with a checklist](https://github.com/allenai/tango/pull/227#issuecomment-1067314997) to future Dependabot PRs that upgrade PyTorch.