### PR TITLE
fix bug w/ TorchTrainStep working dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed bug that mistakenly disallowed fully-qualified names containing `"_"` (underscores) in the config.
+- Fixed bug where `TorchTrainStep` working directory would be left in an unrecoverable state if training failed after saving the final model weights.
 
 ### Changed
 

--- a/tango/integrations/torch/train.py
+++ b/tango/integrations/torch/train.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import shutil
 from itertools import islice
 from typing import Any, Dict, List, Optional, Set, cast
@@ -666,6 +667,10 @@ def _train(
         callback.post_train_loop(step, current_epoch)
 
     if config.is_local_main_process:
+        # It's possible this file already exists if the step previously failed after
+        # already saving the final weights.
+        if config.final_weights_path.is_file():
+            os.remove(config.final_weights_path)
         training_engine.save_complete_weights_from_checkpoint(
             config.best_state_path, config.final_weights_path
         )


### PR DESCRIPTION
<!-- To ensure we can review your pull request promptly please complete this template entirely. -->

<!-- Please reference the issue number here. You can replace "Fixes" with "Closes" if it makes more sense. -->
Fixes #237 

Changes proposed in this pull request:
<!-- Please list all changes/additions here. -->
- Fixes a bug where `TorchTrainStep` working directory would be left in an unrecoverable state if training failed _after_ saving the final model weights.

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [x] I've read and followed all steps in the [Making a pull request](https://github.com/allenai/tango/blob/main/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [x] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/allenai/tango/blob/main/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.

## After submitting

<!-- Please complete this checklist AFTER submitting your PR to speed along the review process. -->
- [ ] All GitHub Actions jobs for my pull request have passed.
