### PR TITLE
Steps cannot take `Model` as input

### DIFF
--- a/tango/integrations/torch/model.py
+++ b/tango/integrations/torch/model.py
@@ -1,3 +1,5 @@
+# from typing import Any, Dict
+
 import torch
 
 from tango.common.registrable import Registrable
@@ -10,3 +12,6 @@ class Model(torch.nn.Module, Registrable):
     Its :meth:`~torch.nn.Module.forward()` method should return a :class:`dict` that
     includes the ``loss`` during training and any tracked metrics during validation.
     """
+
+    # def _to_params(self) -> Dict[str, Any]:
+    #     return {}

--- a/tests/integrations/torch/model_test.py
+++ b/tests/integrations/torch/model_test.py
@@ -1,0 +1,52 @@
+import pytest
+from torch import nn
+
+from tango.common.testing import TangoTestCase
+from tango.integrations.torch import Model
+from tango.step import Step
+
+
+class FeedForward(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear = nn.Linear(4, 4)
+        self.activation = nn.ReLU()
+
+    def forward(self, x):
+        return self.activation(self.linear(x))
+
+
+@Model.register("simple_regression_model", exist_ok=True)
+class SimpleRegressionModel(Model):
+    def __init__(self):
+        super().__init__()
+        self.blocks = nn.Sequential(*[FeedForward() for _ in range(3)])
+        self.regression_head = nn.Linear(4, 1)
+        self.loss_fcn = nn.MSELoss()
+
+    def forward(self, x, y):
+        output = self.blocks(x)
+        output = self.regression_head(output)
+        loss = self.loss_fcn(output, y)
+        return {"loss": loss}
+
+
+@Step.register("step-that-takes-model-as-input")
+class StepThatTakesModelAsInput(Step):
+    def run(self, model: Model) -> Model:  # type: ignore
+        return model
+
+
+class TestModelAsStepInput(TangoTestCase):
+    def test_step_that_takes_model_as_input(self):
+        config = {
+            "steps": {
+                "model": {
+                    "type": "step-that-takes-model-as-input",
+                    "model": {"type": "simple_regression_model"},
+                }
+            }
+        }
+
+        with pytest.raises(NotImplementedError):
+            self.run(config)


### PR DESCRIPTION
Right now, steps cannot take `Model` object as inputs, unless `_to_params()` is implemented. As it's unreasonable to expect users to write `_to_params()` for every implementation, we can add any empty implementation of it in the base class. However, that may lead to incorrect hashing for the object potentially? 

Error observed:

```
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
../../tango/common/testing.py:87: in run
    run_name = _run(
../../tango/__main__.py:707: in _run
    run = workspace.register_run((step for step in step_graph.values()), name)
../../tango/workspaces/local_workspace.py:345: in register_run
    all_steps = set(targets)
../../tango/step.py:452: in __hash__
    return hash(self.unique_id)
../../tango/step.py:431: in unique_id
    self.unique_id_cache += det_hash(
../../tango/common/det_hash.py:128: in det_hash
    pickler.dump(o)
../../../../../virtuals/tango/lib/python3.8/site-packages/dill/_dill.py:498: in dump
    StockPickler.dump(self, obj)
/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/pickle.py:485: in dump
    self.save(obj)
../../tango/common/det_hash.py:102: in save
    super().save(obj, save_persistent_id)
/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/pickle.py:558: in save
    f(self, obj)  # Call unbound method with explicit self
/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/pickle.py:884: in save_tuple
    save(element)
../../tango/common/det_hash.py:102: in save
    super().save(obj, save_persistent_id)
/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/pickle.py:558: in save
    f(self, obj)  # Call unbound method with explicit self
../../../../../virtuals/tango/lib/python3.8/site-packages/dill/_dill.py:990: in save_module_dict
    StockPickler.save_dict(pickler, obj)
/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/pickle.py:969: in save_dict
    self._batch_setitems(obj.items())
/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/pickle.py:1000: in _batch_setitems
    save(v)
../../tango/common/det_hash.py:102: in save
    super().save(obj, save_persistent_id)
/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/pickle.py:537: in save
    pid = self.persistent_id(obj)
../../tango/common/det_hash.py:107: in persistent_id
    det_hash_object = obj.det_hash_object()
../../tango/common/from_params.py:838: in det_hash_object
    r = (self.__class__.__qualname__, self.to_params())
../../tango/common/from_params.py:820: in to_params
    return Params(replace_object_with_params(self._to_params()))
../../tango/common/from_params.py:809: in replace_object_with_params
    return {key: replace_object_with_params(value) for key, value in o.items()}
../../tango/common/from_params.py:809: in <dictcomp>
    return {key: replace_object_with_params(value) for key, value in o.items()}
../../tango/common/from_params.py:809: in replace_object_with_params
    return {key: replace_object_with_params(value) for key, value in o.items()}
../../tango/common/from_params.py:809: in <dictcomp>
    return {key: replace_object_with_params(value) for key, value in o.items()}
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

o = Sequential(
  (0): FeedForward(
    (linear): Linear(in_features=4, out_features=4, bias=True)
    (activation): ReLU(...)
  )
  (2): FeedForward(
    (linear): Linear(in_features=4, out_features=4, bias=True)
    (activation): ReLU()
  )
)

    def replace_object_with_params(o: Any) -> Any:
        if isinstance(o, FromParams):
            return o.to_params().as_dict(quiet=True)
        elif isinstance(o, (list, tuple, set)):
            return [replace_object_with_params(i) for i in o]
        elif isinstance(o, dict):
            return {key: replace_object_with_params(value) for key, value in o.items()}
        elif isinstance(o, Path):
            return str(o)
        elif o is None or isinstance(o, (str, float, int, bool)):
            return o
        else:
>           raise NotImplementedError(
                f"Unexpected type encountered in to_params(): {o} ({type(o)})\n"
                "You may need to implement a custom '_to_params()'."
            )
E           NotImplementedError: Unexpected type encountered in to_params(): Sequential(
E             (0): FeedForward(
E               (linear): Linear(in_features=4, out_features=4, bias=True)
E               (activation): ReLU()
E             )
E             (1): FeedForward(
E               (linear): Linear(in_features=4, out_features=4, bias=True)
E               (activation): ReLU()
E             )
E             (2): FeedForward(
E               (linear): Linear(in_features=4, out_features=4, bias=True)
E               (activation): ReLU()
E             )
E           ) (<class 'torch.nn.modules.container.Sequential'>)
E           You may need to implement a custom '_to_params()'.

../../tango/common/from_params.py:815: NotImplementedError
```