### PR TITLE
Add Beaker integration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -109,6 +109,12 @@ jobs:
             run: |
               pytest -v --color=yes --doctest-modules tango/integrations/wandb tests/integrations/wandb
 
+          - name: Beaker integration
+            extras: dev,beaker
+            requires_torch: false
+            run: |
+              pytest -v --color=yes --doctest-modules tango/integrations/beaker tests/integrations/beaker
+
           - name: Example - train_lm
             extras: dev,all
             requires_torch: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - If you try to import something from a tango integration that is not fully installed due to missing dependencies, an `IntegrationMissingError` will be raised
 instead of `ModuleNotFound`.
+- You can now set `-j 0` in `tango run` to disable multicore execution altogether.
 
 ## [v0.8.0](https://github.com/allenai/tango/releases/tag/v0.8.0) - 2022-05-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 instead of `ModuleNotFound`.
 - You can now set `-j 0` in `tango run` to disable multicore execution altogether.
 
+### Fixed
+
+- Improved how steps and workspaces handle race conditions when different processes are competing to execute the same step. This would result in a `RuntimeError` before with most workspaces, but now it's handled gracefully.
+
 ## [v0.8.0](https://github.com/allenai/tango/releases/tag/v0.8.0) - 2022-05-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Added a [Beaker](https://beaker.org) integration that comes with `BeakerWorkspace`, a remote `Workspace` implementation that uses Beaker Datasets under the hood.
+
 ### Changed
 
 - If you try to import something from a tango integration that is not fully installed due to missing dependencies, an `IntegrationMissingError` will be raised

--- a/docs/source/api/integrations/beaker.rst
+++ b/docs/source/api/integrations/beaker.rst
@@ -1,0 +1,11 @@
+🧪 Beaker
+=========
+
+.. automodule:: tango.integrations.beaker
+
+Reference
+---------
+
+.. autoclass:: tango.integrations.beaker.BeakerWorkspace
+
+.. autoclass:: tango.integrations.beaker.BeakerStepCache

--- a/docs/source/api/integrations/index.rst
+++ b/docs/source/api/integrations/index.rst
@@ -13,3 +13,4 @@ Integrations
    transformers
    wandb
    pytorch_lightning
+   beaker

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -66,6 +66,7 @@ intersphinx_mapping = {
     "fairscale": ("https://fairscale.readthedocs.io/en/latest/", None),
     "datasets": ("https://huggingface.co/docs/datasets/master/en", None),
     "transformers": ("https://huggingface.co/docs/transformers/master/en", None),
+    "beaker": ("https://beaker-py.readthedocs.io/en/latest/", None),
 }
 
 # Tell myst-parser to assign header anchors for h1-h3.

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ xxhash
 filelock>=3.4,<3.7
 click>=7.0,<8.1.4
 click-help-colors>=0.9.1,<0.10
-rich>=11.0,<13.0
+rich>=12.3,<13.0
 tqdm>=4.62,<4.65
 more-itertools>=8.0,<9.0
 sqlitedict
@@ -32,6 +32,7 @@ pytorch-lightning>=1.6,<1.7  # needed by: pytorch_lightning
 transformers>=4.12.3         # needed by: transformers
 sentencepiece>=0.1.96        # needed by: transformers
 fairscale==0.4.6             # needed by: fairscale
+beaker-py>=1.2.0,<2.0.0      # needed by: beaker
 
 # sacremoses should be a dependency of transformers, but it is missing, so we add it manually.
 sacremoses                   # needed by: transformers

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ pytorch-lightning>=1.6,<1.7  # needed by: pytorch_lightning
 transformers>=4.12.3         # needed by: transformers
 sentencepiece>=0.1.96        # needed by: transformers
 fairscale==0.4.6             # needed by: fairscale
-beaker-py>=1.2.0,<2.0.0      # needed by: beaker
+beaker-py>=1.3.0,<2.0.0      # needed by: beaker
 
 # sacremoses should be a dependency of transformers, but it is missing, so we add it manually.
 sacremoses                   # needed by: transformers

--- a/tango/__main__.py
+++ b/tango/__main__.py
@@ -682,6 +682,8 @@ def _run(
             # Pydevd doesn't reliably follow child processes, so we disable multicore under the debugger.
             logger.warning("Debugger detected, disabling multicore.")
             multicore = False
+        elif parallelism <= 0:
+            multicore = False
         else:
             multicore = True
 

--- a/tango/__main__.py
+++ b/tango/__main__.py
@@ -822,7 +822,7 @@ def _display_run_results(
             "\n".join(
                 [
                     ">>> from tango import Workspace",
-                    ">>> workspace = Workspace.from_url(...)",
+                    f'>>> workspace = Workspace.from_url("{workspace.url}")',
                     f'>>> workspace.step_result_for_run("{run.name}", "{last_cached_step}")',
                 ]
             ),

--- a/tango/common/exceptions.py
+++ b/tango/common/exceptions.py
@@ -1,4 +1,8 @@
-from typing import Any, Optional, Set, Tuple, Union
+from typing import TYPE_CHECKING, Any, Optional, Set, Tuple, Union
+
+if TYPE_CHECKING:
+    from tango.step import Step
+    from tango.step_info import StepInfo, StepState
 
 
 class TangoError(Exception):
@@ -55,4 +59,23 @@ class IntegrationMissingError(TangoError):
             f"'{self.integration}' integration can't be used due to "
             f"missing dependencies ({', '.join(self.dependencies)})"
         )
+        super().__init__(msg)
+
+
+class StepStateError(TangoError):
+    """
+    Raised when a step is in an unexpected state.
+    """
+
+    def __init__(
+        self,
+        step: Union["Step", "StepInfo"],
+        step_state: "StepState",
+        context: Optional[str] = None,
+    ):
+        self.step_state = step_state
+        self.step_id = step.unique_id
+        msg = f"Step '{self.step_id}' is in unexpected state '{self.step_state.value}'"
+        if context is not None:
+            msg = msg + " " + context
         super().__init__(msg)

--- a/tango/common/file_lock.py
+++ b/tango/common/file_lock.py
@@ -41,11 +41,11 @@ class FileLock(_FileLock):  # type: ignore[valid-type,misc]
                     "Race conditions are possible if other processes are writing to the same resource.",
                     UserWarning,
                 )
-                return None  # type: ignore[return-value]
+                return AcquireReturnProxy(self)
             else:
                 raise
 
-    def acquire_with_updates(self, desc: Optional[str] = None):
+    def acquire_with_updates(self, desc: Optional[str] = None) -> AcquireReturnProxy:
         """
         Same as :meth:`acquire()`, except that when the lock cannot be immediately acquired,
         it will keep trying and print status updates as it goes.

--- a/tango/common/file_lock.py
+++ b/tango/common/file_lock.py
@@ -52,7 +52,7 @@ class FileLock(_FileLock):  # type: ignore[valid-type,misc]
         """
         try:
             return self.acquire(timeout=0.1)
-        except Timeout:
+        except TimeoutError:
             pass
 
         from .tqdm import Tqdm

--- a/tango/common/file_lock.py
+++ b/tango/common/file_lock.py
@@ -4,7 +4,6 @@ from typing import Optional
 
 from filelock import AcquireReturnProxy
 from filelock import FileLock as _FileLock
-from filelock import Timeout
 
 from .aliases import PathOrStr
 
@@ -66,5 +65,5 @@ class FileLock(_FileLock):  # type: ignore[valid-type,misc]
             progress.update()
             try:
                 return self.acquire(timeout=1)
-            except Timeout:
+            except TimeoutError:
                 continue

--- a/tango/integrations/beaker/__init__.py
+++ b/tango/integrations/beaker/__init__.py
@@ -1,0 +1,20 @@
+"""
+.. important::
+    To use this integration you should install ``tango`` with the "beaker" extra
+    (e.g. ``pip install tango[beaker]``) or just install the `beaker-py <https://beaker-py.readthedocs.io>`_
+    library after the fact (e.g. ``pip install beaker-py``).
+
+Components for Tango integration with `Beaker <https://beaker.org/>`_.
+"""
+
+from tango.common.exceptions import IntegrationMissingError
+
+try:
+    import beaker
+except ModuleNotFoundError:
+    raise IntegrationMissingError("beaker", dependencies={"beaker-py"})
+
+from .step_cache import BeakerStepCache
+from .workspace import BeakerWorkspace
+
+__all__ = ["BeakerStepCache", "BeakerWorkspace"]

--- a/tango/integrations/beaker/common.py
+++ b/tango/integrations/beaker/common.py
@@ -1,5 +1,11 @@
-from typing import Union
+import time
+from typing import Optional, Union
 
+from beaker import Beaker, Dataset, DatasetConflict
+from filelock import AcquireReturnProxy
+
+from tango.common.aliases import PathOrStr
+from tango.common.file_lock import FileLock
 from tango.step import Step
 from tango.step_info import StepInfo
 
@@ -16,5 +22,39 @@ def step_dataset_name(step: Union[str, StepInfo, Step]) -> str:
     return f"{Constants.STEP_DATASET_PREFIX}{step if isinstance(step, str) else step.unique_id}"
 
 
+def step_lock_dataset_name(step: Union[str, StepInfo, Step]) -> str:
+    return f"{step_dataset_name(step)}-lock"
+
+
 def run_dataset_name(name: str) -> str:
     return f"{Constants.RUN_DATASET_PREFIX}{name}"
+
+
+class BeakerLock(FileLock):
+    def __init__(self, lock_file: PathOrStr, beaker: Beaker, lock_dataset: str, **kwargs):
+        super().__init__(lock_file, **kwargs)
+        self._beaker = beaker
+        self._lock_dataset_name = lock_dataset
+        self._lock_dataset: Optional[Dataset] = None
+
+    def acquire(self, timeout=None, poll_interval=0.05) -> AcquireReturnProxy:
+        start = time.monotonic()
+        while timeout is None or (time.monotonic() - start < timeout):
+            try:
+                self._lock_dataset = self._beaker.dataset.create(self._lock_dataset_name)
+            except DatasetConflict:
+                continue
+            else:
+                break
+        else:
+            raise TimeoutError(
+                f"Timeout error waiting to acquire dataset lock "
+                f"{self._beaker.dataset.url(self.lock_dataset_name)}"
+            )
+        return super().acquire(timeout=timeout, poll_interval=poll_interval)
+
+    def release(self, force: bool = False):
+        if self._lock_dataset is not None:
+            self._beaker.dataset.delete(self._lock_dataset)
+            self._lock_dataset = None
+        super().release(force=force)

--- a/tango/integrations/beaker/common.py
+++ b/tango/integrations/beaker/common.py
@@ -1,0 +1,20 @@
+from typing import Union
+
+from tango.step import Step
+from tango.step_info import StepInfo
+
+
+class Constants:
+    RUN_DATASET_PREFIX = "tango-run-"
+    RUN_DATA_FNAME = "run.json"
+    STEP_DATASET_PREFIX = "tango-step-"
+    STEP_INFO_FNAME = "step_info.json"
+    STEP_RESULT_DIR = "result"
+
+
+def step_dataset_name(step: Union[str, StepInfo, Step]) -> str:
+    return f"{Constants.STEP_DATASET_PREFIX}{step if isinstance(step, str) else step.unique_id}"
+
+
+def run_dataset_name(name: str) -> str:
+    return f"{Constants.RUN_DATASET_PREFIX}{name}"

--- a/tango/integrations/beaker/step_cache.py
+++ b/tango/integrations/beaker/step_cache.py
@@ -167,12 +167,10 @@ class BeakerStepCache(LocalStepCache):
         self._add_to_cache(step.unique_id, value)
 
     def __len__(self) -> int:
-        return len(
-            [
-                ds
+        return sum(
+                1
                 for ds in self.beaker.workspace.datasets(
                     uncommitted=False, match=Constants.STEP_DATASET_PREFIX
                 )
                 if ds.name is not None and ds.name.startswith(Constants.STEP_DATASET_PREFIX)
-            ]
         )

--- a/tango/integrations/beaker/step_cache.py
+++ b/tango/integrations/beaker/step_cache.py
@@ -1,0 +1,178 @@
+import logging
+import os
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Any, Optional, Union
+
+from beaker import Beaker, Dataset, DatasetConflict, DatasetNotFound, DatasetWriteError
+
+from tango.common.file_lock import FileLock
+from tango.common.params import Params
+from tango.common.util import tango_cache_dir
+from tango.step import Step
+from tango.step_cache import CacheMetadata, StepCache
+from tango.step_caches.local_step_cache import LocalStepCache
+from tango.step_info import StepInfo
+
+from .common import Constants, step_dataset_name
+
+logger = logging.getLogger(__name__)
+
+
+@StepCache.register("beaker")
+class BeakerStepCache(LocalStepCache):
+    """
+    This is a :class:`~tango.step_cache.StepCache` that's used by :class:`BeakerWorkspace`.
+    It stores the results of steps on Beaker as datasets.
+
+    It also keeps a limited in-memory cache as well as a local backup on disk, so fetching a
+    step's resulting subsequent times should be fast.
+
+    :param workspace: The name or ID of the Beaker workspace to use.
+    :param beaker: The Beaker client to use.
+
+    .. tip::
+        Registered as :class:`~tango.step_cache.StepCache` under the name "beaker".
+    """
+
+    def __init__(self, workspace: Optional[str] = None, beaker: Optional[Beaker] = None):
+        super().__init__(tango_cache_dir() / "beaker_cache")
+        self.beaker: Beaker
+        if beaker is not None:
+            self.beaker = beaker
+            if workspace is not None:
+                self.beaker.config.default_workspace = workspace
+                self.beaker.workspace.ensure(workspace)
+        elif workspace is not None:
+            self.beaker = Beaker.from_env(default_workspace=workspace)
+        else:
+            self.beaker = Beaker.from_env()
+
+    def _acquire_step_lock_file(self, step: Union[Step, StepInfo], read_only_ok: bool = False):
+        return FileLock(
+            self.step_dir(step).with_suffix(".lock"), read_only_ok=read_only_ok
+        ).acquire_with_updates(desc=f"acquiring step cache lock for '{step.unique_id}'")
+
+    def _step_result_dataset(self, step: Union[Step, StepInfo]) -> Optional[Dataset]:
+        try:
+            dataset = self.beaker.dataset.get(step_dataset_name(step))
+            return dataset if dataset.committed is not None else None
+        except DatasetNotFound:
+            return None
+
+    def _sync_step_dataset(self, step: Step, objects_dir: Path) -> Dataset:
+        dataset_name = step_dataset_name(step)
+        try:
+            dataset = self.beaker.dataset.create(dataset_name, commit=False)
+        except DatasetConflict:
+            dataset = self.beaker.dataset.get(dataset_name)
+
+        try:
+            self.beaker.dataset.sync(dataset, objects_dir, quiet=True)
+            dataset = self.beaker.dataset.commit(dataset)
+        except DatasetWriteError:
+            pass
+
+        return dataset
+
+    def __contains__(self, step: Any) -> bool:
+        if isinstance(step, (Step, StepInfo)):
+            cacheable = step.cache_results if isinstance(step, Step) else step.cacheable
+            if not cacheable:
+                return False
+
+            key = step.unique_id
+
+            # First check if we have a copy in memory.
+            if key in self.strong_cache:
+                return True
+            if key in self.weak_cache:
+                return True
+
+            # Then check if we have a copy on disk in our cache directory.
+            with self._acquire_step_lock_file(step, read_only_ok=True):
+                if (self.step_dir(step) / Constants.STEP_RESULT_DIR).is_dir():
+                    return True
+
+            # If not, check Beaker for the corresponding dataset.
+            return self._step_result_dataset(step) is not None
+        else:
+            return False
+
+    def __getitem__(self, step: Union[Step, StepInfo]) -> Any:
+        key = step.unique_id
+
+        # Try getting the result from our in-memory caches first.
+        result = self._get_from_cache(key)
+        if result is not None:
+            return result
+
+        def load_and_return():
+            metadata = CacheMetadata.from_params(Params.from_file(self._metadata_path(step)))
+            result = metadata.format.read(self.step_dir(step) / Constants.STEP_RESULT_DIR)
+            self._add_to_cache(key, result)
+            return result
+
+        # Next check our local on-disk cache.
+        with self._acquire_step_lock_file(step, read_only_ok=True):
+            if self.step_dir(step).is_dir():
+                return load_and_return()
+
+        # Finally, check Beaker for the corresponding dataset.
+        with self._acquire_step_lock_file(step):
+            # Make sure the step wasn't cached since the last time we checked (above).
+            if self.step_dir(step).is_dir():
+                return load_and_return()
+
+            dataset = self._step_result_dataset(step)
+            if dataset is None:
+                raise KeyError(step)
+
+            # We'll download the dataset to a temporary directory first, in case something goes wrong.
+            temp_dir = tempfile.mkdtemp(dir=self.dir, prefix=key)
+            try:
+                self.beaker.dataset.fetch(dataset, target=temp_dir, quiet=True)
+                # Download and extraction was successful, rename temp directory to final step result directory.
+                os.replace(temp_dir, self.step_dir(step))
+            finally:
+                shutil.rmtree(temp_dir, ignore_errors=True)
+
+            return load_and_return()
+
+    def __setitem__(self, step: Step, value: Any) -> None:
+        if not step.cache_results:
+            logger.warning("Tried to cache step %s despite being marked as uncacheable.", step.name)
+            return
+
+        with self._acquire_step_lock_file(step):
+            # We'll write the step's results to temporary directory first, and try to upload to
+            # Beaker from there in case anything goes wrong.
+            temp_dir = Path(tempfile.mkdtemp(dir=self.dir, prefix=step.unique_id))
+            (temp_dir / Constants.STEP_RESULT_DIR).mkdir()
+            try:
+                step.format.write(value, temp_dir / Constants.STEP_RESULT_DIR)
+                metadata = CacheMetadata(step=step.unique_id, format=step.format)
+                metadata.to_params().to_file(temp_dir / self.METADATA_FILE_NAME)
+                # Create the dataset and upload serialized result to it.
+                self._sync_step_dataset(step, temp_dir)
+                # Upload successful, rename temp directory to the final step result directory.
+                if self.step_dir(step).is_dir():
+                    shutil.rmtree(self.step_dir(step), ignore_errors=True)
+                os.replace(temp_dir, self.step_dir(step))
+            finally:
+                shutil.rmtree(temp_dir, ignore_errors=True)
+
+        # Finally, add to in-memory caches.
+        self._add_to_cache(step.unique_id, value)
+
+    def __len__(self) -> int:
+        return len(
+            [
+                ds
+                for ds in self.beaker.workspace.datasets(
+                    uncommitted=False, match=Constants.STEP_DATASET_PREFIX
+                )
+                if ds.name is not None and ds.name.startswith(Constants.STEP_DATASET_PREFIX)
+            ]
+        )

--- a/tango/integrations/beaker/step_cache.py
+++ b/tango/integrations/beaker/step_cache.py
@@ -168,9 +168,9 @@ class BeakerStepCache(LocalStepCache):
 
     def __len__(self) -> int:
         return sum(
-                1
-                for ds in self.beaker.workspace.datasets(
-                    uncommitted=False, match=Constants.STEP_DATASET_PREFIX
-                )
-                if ds.name is not None and ds.name.startswith(Constants.STEP_DATASET_PREFIX)
+            1
+            for ds in self.beaker.workspace.datasets(
+                uncommitted=False, match=Constants.STEP_DATASET_PREFIX
+            )
+            if ds.name is not None and ds.name.startswith(Constants.STEP_DATASET_PREFIX)
         )

--- a/tango/integrations/beaker/step_cache.py
+++ b/tango/integrations/beaker/step_cache.py
@@ -153,6 +153,8 @@ class BeakerStepCache(LocalStepCache):
         self._add_to_cache(step.unique_id, value)
 
     def __len__(self) -> int:
+        # NOTE: lock datasets should not count here. They start with the same prefix,
+        # but they never get committed.
         return sum(
             1
             for ds in self.beaker.workspace.datasets(

--- a/tango/integrations/beaker/workspace.py
+++ b/tango/integrations/beaker/workspace.py
@@ -267,9 +267,6 @@ class BeakerWorkspace(Workspace):
         except DatasetConflict:
             step_info_dataset = self.beaker.dataset.get(dataset_name)
 
-        if step_info_dataset.committed:
-            return
-
         with tempfile.TemporaryDirectory() as tmp_dir_name:
             tmp_dir = Path(tmp_dir_name)
             step_info_path = tmp_dir / Constants.STEP_INFO_FNAME

--- a/tango/integrations/beaker/workspace.py
+++ b/tango/integrations/beaker/workspace.py
@@ -1,0 +1,278 @@
+import json
+import random
+import tempfile
+from collections import OrderedDict
+from pathlib import Path
+from typing import Dict, Iterable, Iterator, Optional, TypeVar, Union, cast
+from urllib.parse import ParseResult
+
+import petname
+from beaker import Beaker, Dataset, DatasetConflict, DatasetNotFound, Digest
+
+from tango.common.file_lock import FileLock
+from tango.common.util import exception_to_string, tango_cache_dir, utc_now_datetime
+from tango.step import Step
+from tango.step_cache import StepCache
+from tango.step_info import StepInfo, StepState
+from tango.workspace import Run, Workspace
+
+from .common import Constants, run_dataset_name, step_dataset_name
+from .step_cache import BeakerStepCache
+
+T = TypeVar("T")
+
+
+@Workspace.register("beaker")
+class BeakerWorkspace(Workspace):
+    """
+    This is a :class:`~tango.workspace.Workspace` that stores step artifacts on `Beaker`_.
+
+    :param workspace: The name or ID of the Beaker workspace to use.
+    :param kwargs: Additional keyword arguments passed to :meth:`Beaker.from_env() <beaker.Beaker.from_env()>`.
+
+    .. tip::
+        Registered as :class:`~tango.workspace.Workspace` under the name "beaker".
+    """
+
+    STEP_INFO_CACHE_SIZE = 512
+
+    def __init__(self, workspace: str, **kwargs):
+        super().__init__()
+        self.beaker = Beaker.from_env(default_workspace=workspace, **kwargs)
+        self.cache = BeakerStepCache(beaker=self.beaker)
+        self.steps_dir = tango_cache_dir() / "beaker_workspace"
+        self.locks: Dict[Step, FileLock] = {}
+        self._step_info_cache: "OrderedDict[Digest, StepInfo]" = OrderedDict()
+
+    @property
+    def url(self) -> str:
+        return f"beaker://{self.beaker.workspace.get().full_name}"
+
+    @classmethod
+    def from_parsed_url(cls, parsed_url: ParseResult) -> Workspace:
+        workspace: str
+        if parsed_url.netloc and parsed_url.path:
+            # e.g. "beaker://ai2/my-workspace"
+            workspace = parsed_url.netloc + parsed_url.path
+        elif parsed_url.netloc:
+            # e.g. "beaker://my-workspace"
+            workspace = parsed_url.netloc
+        else:
+            raise ValueError(f"Bad URL for Beaker workspace '{parsed_url}'")
+        return cls(workspace)
+
+    @property
+    def step_cache(self) -> StepCache:
+        return self.cache
+
+    def step_dir(self, step_or_unique_id: Union[Step, str]) -> Path:
+        unique_id = (
+            step_or_unique_id if isinstance(step_or_unique_id, str) else step_or_unique_id.unique_id
+        )
+        path = self.steps_dir / unique_id
+        path.mkdir(parents=True, exist_ok=True)
+        return path
+
+    def work_dir(self, step: Step) -> Path:
+        path = self.step_dir(step) / "work"
+        path.mkdir(parents=True, exist_ok=True)
+        return path
+
+    def step_info(self, step_or_unique_id: Union[Step, str]) -> StepInfo:
+        try:
+            dataset = self.beaker.dataset.get(step_dataset_name(step_or_unique_id))
+            file_info = self.beaker.dataset.file_info(dataset, Constants.STEP_INFO_FNAME)
+            step_info: StepInfo
+            if file_info.digest in self._step_info_cache:
+                step_info = self._step_info_cache.pop(file_info.digest)
+            else:
+                step_info_bytes = b"".join(
+                    self.beaker.dataset.stream_file(dataset, file_info, quiet=True)
+                )
+                step_info = StepInfo.from_json_dict(json.loads(step_info_bytes))
+            self._step_info_cache[file_info.digest] = step_info
+            while len(self._step_info_cache) > self.STEP_INFO_CACHE_SIZE:
+                self._step_info_cache.popitem(last=False)
+            return step_info
+        except (DatasetNotFound, FileNotFoundError):
+            raise KeyError(step_or_unique_id)
+
+    def step_starting(self, step: Step) -> None:
+        # We don't do anything with uncacheable steps.
+        if not step.cache_results:
+            return
+
+        lock_path = self.step_dir(step) / "lock"
+        lock = FileLock(lock_path, read_only_ok=True)
+        lock.acquire_with_updates(desc=f"acquiring lock for '{step.name}'")
+        self.locks[step] = lock
+        step_info = self.step_info(step)
+        if step_info.state not in {StepState.INCOMPLETE, StepState.FAILED, StepState.UNCACHEABLE}:
+            raise RuntimeError(
+                f"Step '{step.name}' is trying to start, but it is already {step_info.state}. "
+                f"If you are certain the step is not running somewhere else, delete the lock step info "
+                f"Beaker dataset at {self.beaker.dataset.url(step_dataset_name(step))}"
+            )
+
+        # Update StepInfo to mark as running.
+        try:
+            step_info.start_time = utc_now_datetime()
+            step_info.end_time = None
+            step_info.error = None
+            step_info.result_location = None
+            self._update_step_info(step_info)
+        except:  # noqa: E722
+            lock.release()
+            del self.locks[step]
+            raise
+
+    def step_finished(self, step: Step, result: T) -> T:
+        # We don't do anything with uncacheable steps.
+        if not step.cache_results:
+            return result
+
+        step_info = self.step_info(step)
+        if step_info.state != StepState.RUNNING:
+            raise RuntimeError(f"Step '{step.name}' is ending, but it never started.")
+
+        # Update step info. This needs to be done *before* adding the result to the cache,
+        # since adding the result to the cache will commit the step dataset, making it immutable.
+        step_info.end_time = utc_now_datetime()
+        step_info.result_location = self.beaker.dataset.url(step_dataset_name(step))
+        self._update_step_info(step_info)
+
+        self.cache[step] = result
+        if hasattr(result, "__next__"):
+            assert isinstance(result, Iterator)
+            # Caching the iterator will consume it, so we write it to the cache and then read from the cache
+            # for the return value.
+            result = self.cache[step]
+
+        self.locks.pop(step).release()
+
+        return result
+
+    def step_failed(self, step: Step, e: BaseException) -> None:
+        # We don't do anything with uncacheable steps.
+        if not step.cache_results:
+            return
+
+        try:
+            step_info = self.step_info(step)
+            if step_info.state != StepState.RUNNING:
+                raise RuntimeError(f"Step '{step.name}' is failing, but it never started.")
+            step_info.end_time = utc_now_datetime()
+            step_info.error = exception_to_string(e)
+            self._update_step_info(step_info)
+        finally:
+            self.locks.pop(step).release()
+
+    def register_run(self, targets: Iterable[Step], name: Optional[str] = None) -> Run:
+        all_steps = set(targets)
+        for step in targets:
+            all_steps |= step.recursive_dependencies
+
+        # Create a Beaker dataset that represents this run. The dataset which just contain
+        # a JSON file that maps step names to step unique IDs.
+        run_dataset: Dataset
+        if name is None:
+            # Find a unique name to use.
+            while True:
+                name = petname.generate() + str(random.randint(0, 100))
+                try:
+                    run_dataset = self.beaker.dataset.create(
+                        run_dataset_name(cast(str, name)), commit=False
+                    )
+                except DatasetConflict:
+                    continue
+                else:
+                    break
+        else:
+            try:
+                run_dataset = self.beaker.dataset.create(name, commit=False)
+            except DatasetConflict:
+                raise ValueError("Run name '{name}' is already in use")
+
+        # Collect step info and add data to run dataset.
+        steps: Dict[str, StepInfo] = {}
+        run_data: Dict[str, str] = {}
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            tmp_dir = Path(tmp_dir_name)
+
+            for step in all_steps:
+                if step.name is None:
+                    continue
+
+                step_info = self._get_or_set_step_info(step)
+                steps[step.name] = step_info
+                run_data[step.name] = step.unique_id
+
+            with open(tmp_dir / Constants.RUN_DATA_FNAME, "w") as f:
+                json.dump(run_data, f)
+
+            self.beaker.dataset.sync(run_dataset, tmp_dir / Constants.RUN_DATA_FNAME, quiet=True)
+
+        # Commit the run dataset. It won't need to change again.
+        self.beaker.dataset.commit(run_dataset)
+
+        return Run(name=cast(str, name), steps=steps, start_date=run_dataset.created)
+
+    def registered_runs(self) -> Dict[str, Run]:
+        runs: Dict[str, Run] = {}
+        # TODO: do these requests concurrently
+        for dataset in self.beaker.workspace.datasets(uncommitted=False):
+            if dataset.name is None:
+                continue
+            if dataset.name.startswith(Constants.RUN_DATASET_PREFIX):
+                run = self._get_run_from_dataset(dataset)
+                runs[run.name] = run
+        return runs
+
+    def registered_run(self, name: str) -> Run:
+        try:
+            dataset_for_run = self.beaker.dataset.get(run_dataset_name(name))
+            if dataset_for_run.workspace_ref.id != self.beaker.workspace.get().id:
+                raise DatasetNotFound
+        except DatasetNotFound:
+            raise KeyError(f"Run '{name}' not found in workspace")
+        return self._get_run_from_dataset(dataset_for_run)
+
+    def _get_run_from_dataset(self, dataset: Dataset) -> Run:
+        assert dataset.name is not None
+        run_name = dataset.name[len(Constants.RUN_DATASET_PREFIX) :]
+        steps: Dict[str, StepInfo] = {}
+        steps_info_bytes = b"".join(
+            self.beaker.dataset.stream_file(dataset, Constants.RUN_DATA_FNAME, quiet=True)
+        )
+        steps_info = json.loads(steps_info_bytes)
+        # TODO: do these requests concurrently
+        for step_name, unique_id in steps_info.items():
+            steps[step_name] = self.step_info(unique_id)
+        return Run(name=run_name, start_date=dataset.created, steps=steps)
+
+    def _get_or_set_step_info(self, step: Step) -> StepInfo:
+        try:
+            return self.step_info(step)
+        except KeyError:
+            step_info = StepInfo.new_from_step(step)
+            self._update_step_info(step_info)
+            return step_info
+
+    def _update_step_info(self, step_info: StepInfo):
+        dataset_name = step_dataset_name(step_info)
+
+        step_info_dataset: Dataset
+        try:
+            step_info_dataset = self.beaker.dataset.create(dataset_name, commit=False)
+        except DatasetConflict:
+            step_info_dataset = self.beaker.dataset.get(dataset_name)
+
+        if step_info_dataset.committed:
+            return
+
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            tmp_dir = Path(tmp_dir_name)
+            step_info_path = tmp_dir / Constants.STEP_INFO_FNAME
+            with open(step_info_path, "w") as f:
+                json.dump(step_info.to_json_dict(), f)
+            self.beaker.dataset.sync(step_info_dataset, step_info_path, quiet=True)

--- a/tango/step_info.py
+++ b/tango/step_info.py
@@ -157,7 +157,7 @@ class StepInfo:
                 if isinstance(v, set)
                 else v
             )
-            for k, v in asdict(self).items()
+            for k, v in sorted(asdict(self).items(), key=lambda x: x[0])
         }
 
     @classmethod

--- a/tango/step_info.py
+++ b/tango/step_info.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 from dataclasses import asdict, dataclass
 from datetime import datetime, timedelta
 from enum import Enum
@@ -149,16 +150,19 @@ class StepInfo:
         """
         Generates a JSON-safe, human-readable, dictionary representation of this dataclass.
         """
-        return {
-            k: (
-                v.strftime("%Y-%m-%dT%H:%M:%S")
-                if isinstance(v, datetime)
-                else list(v)
-                if isinstance(v, set)
-                else v
+        return OrderedDict(
+            (
+                k,
+                (
+                    v.strftime("%Y-%m-%dT%H:%M:%S")
+                    if isinstance(v, datetime)
+                    else list(v)
+                    if isinstance(v, set)
+                    else v
+                ),
             )
             for k, v in sorted(asdict(self).items(), key=lambda x: x[0])
-        }
+        )
 
     @classmethod
     def from_json_dict(cls, json_dict: Dict[str, Any]) -> "StepInfo":

--- a/tango/workspace.py
+++ b/tango/workspace.py
@@ -168,6 +168,8 @@ class Workspace(Registrable):
         The :class:`.Step` class calls this when a step is about to start running.
 
         :param step: The step that is about to start.
+
+        :raises StepStateError: If the step is in an unexpected state (e.g. RUNNING).
         """
         raise NotImplementedError()
 
@@ -177,6 +179,8 @@ class Workspace(Registrable):
         The :class:`.Step` class calls this when a step finished running.
 
         :param step: The step that finished.
+
+        :raises StepStateError: If the step is in an unexpected state (e.g. RUNNING).
 
         This method is given the result of the step's :meth:`.Step.run` method. It is expected to return that
         result. This gives it the opportunity to make changes to the result if necessary. For example, if the
@@ -192,6 +196,8 @@ class Workspace(Registrable):
 
         :param step: The step that failed.
         :param e: The exception thrown by the step's :meth:`.Step.run` method.
+
+        :raises StepStateError: If the step is in an unexpected state (e.g. RUNNING).
         """
         raise NotImplementedError()
 

--- a/tango/workspace.py
+++ b/tango/workspace.py
@@ -95,6 +95,7 @@ class Workspace(Registrable):
         return out
 
     @property
+    @abstractmethod
     def url(self) -> str:
         """
         Get a URL for the workspace that can be used to instantiate the same workspace

--- a/tango/workspaces/memory_workspace.py
+++ b/tango/workspaces/memory_workspace.py
@@ -4,6 +4,7 @@ from urllib.parse import ParseResult
 
 import petname
 
+from tango.common.exceptions import StepStateError
 from tango.common.util import exception_to_string, utc_now_datetime
 from tango.step import Step
 from tango.step_cache import StepCache
@@ -73,7 +74,7 @@ class MemoryWorkspace(Workspace):
 
         existing_step_info = self.unique_id_to_info[step.unique_id]
         if existing_step_info.state != StepState.RUNNING:
-            raise RuntimeError(f"Step {step.name} is ending, but it never started.")
+            raise StepStateError(step, existing_step_info.state)
         existing_step_info.end_time = utc_now_datetime()
 
         if step.cache_results:
@@ -93,7 +94,7 @@ class MemoryWorkspace(Workspace):
         assert e is not None
         existing_step_info = self.unique_id_to_info[step.unique_id]
         if existing_step_info.state != StepState.RUNNING:
-            raise RuntimeError(f"Step {step.name} is failing, but it never started.")
+            raise StepStateError(step, existing_step_info.state)
         existing_step_info.end_time = utc_now_datetime()
         existing_step_info.error = exception_to_string(e)
 

--- a/tests/integrations/beaker/conftest.py
+++ b/tests/integrations/beaker/conftest.py
@@ -1,0 +1,46 @@
+import os
+import uuid
+from pathlib import Path
+from typing import Generator
+
+import pytest
+from beaker import Beaker
+
+from tango.common import util
+from tango.integrations.beaker.common import Constants
+from tango.step import Step
+
+
+@pytest.fixture(autouse=True)
+def patched_cache_dir(tmp_path, monkeypatch) -> Path:
+    monkeypatch.setattr(util, "tango_cache_dir", lambda: tmp_path)
+    return tmp_path
+
+
+@pytest.fixture(autouse=True)
+def patched_unique_id_suffix(monkeypatch) -> str:
+    UNIQUE_ID_SUFFIX = os.environ.get("GITHUB_SHA", "")[:6] + "-" + str(uuid.uuid1())[:6]
+    monkeypatch.setattr(Step, "_UNIQUE_ID_SUFFIX", UNIQUE_ID_SUFFIX)
+    return UNIQUE_ID_SUFFIX
+
+
+@pytest.fixture(autouse=True)
+def patched_constants_prefix(monkeypatch) -> str:
+    PREFIX = os.environ.get("GITHUB_SHA", "A")[:6] + "-" + str(uuid.uuid1())[:6] + "-"
+    monkeypatch.setattr(Constants, "STEP_DATASET_PREFIX", "tango-step-" + PREFIX)
+    monkeypatch.setattr(Constants, "RUN_DATASET_PREFIX", "tango-run-" + PREFIX)
+    return PREFIX
+
+
+@pytest.fixture
+def beaker_workspace(
+    patched_unique_id_suffix: str, patched_constants_prefix: str
+) -> Generator[str, None, None]:
+    workspace_name = "ai2/tango-beaker-testing"
+    beaker = Beaker.from_env(default_workspace=workspace_name)
+    yield workspace_name
+    # Remove datasets.
+    for dataset in beaker.workspace.datasets(match=patched_unique_id_suffix):
+        beaker.dataset.delete(dataset)
+    for dataset in beaker.workspace.datasets(match=patched_constants_prefix):
+        beaker.dataset.delete(dataset)

--- a/tests/integrations/beaker/step_cache_test.py
+++ b/tests/integrations/beaker/step_cache_test.py
@@ -1,0 +1,13 @@
+from tango.integrations.beaker.step_cache import BeakerStepCache
+from test_fixtures.package.steps import FloatStep
+
+
+def test_step_cache(beaker_workspace: str):
+    cache = BeakerStepCache(workspace=beaker_workspace)
+
+    step = FloatStep(result=1.0)
+    cache[step] = 1.0
+    assert step in cache
+    assert len(cache) == 1
+    assert FloatStep(result=2.0) not in cache
+    assert cache[step] == 1.0

--- a/tests/integrations/beaker/workspace_test.py
+++ b/tests/integrations/beaker/workspace_test.py
@@ -1,0 +1,23 @@
+from tango.integrations.beaker.workspace import BeakerWorkspace
+from tango.step_info import StepState
+from tango.workspace import Workspace
+from test_fixtures.package.steps import FloatStep
+
+
+def test_from_url(beaker_workspace: str):
+    workspace = Workspace.from_url(f"beaker://{beaker_workspace}")
+    assert isinstance(workspace, BeakerWorkspace)
+
+
+def test_direct_usage(beaker_workspace: str):
+    workspace = BeakerWorkspace(beaker_workspace)
+
+    step = FloatStep(step_name="float", result=1.0)
+    run = workspace.register_run([step])
+
+    assert workspace.step_info(step).state == StepState.INCOMPLETE
+    workspace.step_starting(step)
+    assert workspace.step_info(step).state == StepState.RUNNING
+    workspace.step_finished(step, 1.0)
+    assert workspace.step_info(step).state == StepState.COMPLETED
+    assert workspace.step_result_for_run(run.name, "float") == 1.0

--- a/tests/integrations/beaker/workspace_test.py
+++ b/tests/integrations/beaker/workspace_test.py
@@ -14,6 +14,7 @@ def test_direct_usage(beaker_workspace: str):
 
     step = FloatStep(step_name="float", result=1.0)
     run = workspace.register_run([step])
+    assert run.name in workspace.registered_runs()
 
     assert workspace.step_info(step).state == StepState.INCOMPLETE
     workspace.step_starting(step)


### PR DESCRIPTION
Adds a `BeakerWorkspace`.

Test this out with:

```bash
tango run test_fixtures/experiment/hello_world.jsonnet -i test_fixtures/package -w beaker://ai2/tango-beaker-testing
```

This is a prototype at the moment so I'd like people to try it out. There's still a few enhancements I have planned:
- [x] Capture and upload logs from each run. To implement this, we'd need to implement `BeakerWorkspace.capture_logs_for_run()` similar to how `LocalWorkspace` does it, except maybe we could use a file handler that pipes to a temporary file instead of a "permanent" file. Then we upload that file to the run dataset. So we'd have to postpone committing the run dataset until `__exit__` on the `.capture_logs_for_run()` context manager is called. (90f837f)
- [x] Utilize a thread pool in situations where we could make a bunch of requests concurrently, such as in `BeakerWorkspace.registered_runs()` and `BeakerWorkspace._get_run_from_dataset()`. (49242aa)
- [x] In addition to the local file lock this workspace grabs on `.step_starting()`, we could also grab a "lock" on Beaker. This lock could be implemented using Beaker datasets. E.g.: a process creates a dataset with a deterministic name, and holds that dataset as the lock until it releases it by deleting the dataset. If any other process tried to grab that same lock dataset, they would get a `DatasetConflict` error from Beaker. (1bc7cc3)