### PR TITLE
CONTRIBUTING.md references out of date filename

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -195,5 +195,5 @@ in addition to everything listed in [Making a pull request](#making-a-pull-reque
 5. And then add `name_of_integration` to the `toctree` in `docs/source/api/integrations/index.rst`.
 6. After that, add any additional requirements that your integration depends on to `requirements.txt`. Be sure to put those under the "Extra dependencies for integrations" section,
     and add the special inline comment `# needed by: name_of_integration`.
-7. And finally, in the `checks` job definition in `.github/workflows/ci.yml`, add a new object
+7. And finally, in the `checks` job definition in `.github/workflows/main.yml`, add a new object
     to the matrix for your integration following the other examples there.


### PR DESCRIPTION
<!-- To ensure we can review your pull request promptly please complete this template entirely. -->

<!-- Please reference the issue number here. You can replace "Fixes" with "Closes" if it makes more sense. -->

Changes proposed in this pull request:
<!-- Please list all changes/additions here. -->
- Updates the (Adding a new integration)[https://github.com/allenai/tango/blob/main/CONTRIBUTING.md#adding-a-new-integration] subsection of `CONTRIBUTING.md` to reference `.github/workflows/main.yml` instead of `.github/workflows/ci.yml` as the name of that file has changed

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [x] I've read and followed all steps in the [Making a pull request](https://github.com/allenai/tango/blob/main/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [x] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/allenai/tango/blob/main/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.

## After submitting

<!-- Please complete this checklist AFTER submitting your PR to speed along the review process. -->
- [ ] All GitHub Actions jobs for my pull request have passed.
