### PR TITLE
fix non-deterministic behavior in TorchTrainStep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed non-deterministic behavior in `TorchTrainStep`.
 - Fixed bug in `BeakerWorkspace` where `.step_info(step)` would raise a `KeyError` if the step hasn't been registered as part of a run yet.
 
 ## [v0.9.0](https://github.com/allenai/tango/releases/tag/v0.9.0) - 2022-06-01

--- a/tango/integrations/torch/train.py
+++ b/tango/integrations/torch/train.py
@@ -348,6 +348,14 @@ def _train(
     callbacks: Optional[List[Lazy[TrainCallback]]] = None,
     include_package: Optional[Set[str]] = None,
 ) -> Optional[Model]:
+    # Set random seeds.
+    set_seed_all(config.seed)
+
+    # force torch to be deterministic
+    os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"
+    torch.backends.cudnn.benchmark = False
+    torch.use_deterministic_algorithms(True)
+
     config.worker_id = worker_id
 
     if config.is_distributed and include_package:
@@ -413,9 +421,6 @@ def _train(
         check_dataloader(train_dataloader)
         if validation_dataloader is not None:
             check_dataloader(validation_dataloader)
-
-    # Set random seeds.
-    set_seed_all(config.seed)
 
     batch_loss: float = 0.0
     best_batch_loss: Optional[float] = None

--- a/tango/integrations/torch/train.py
+++ b/tango/integrations/torch/train.py
@@ -351,11 +351,6 @@ def _train(
     # Set random seeds.
     set_seed_all(config.seed)
 
-    # force torch to be deterministic
-    os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"
-    torch.backends.cudnn.benchmark = False
-    torch.use_deterministic_algorithms(True)
-
     config.worker_id = worker_id
 
     if config.is_distributed and include_package:


### PR DESCRIPTION
<!-- To ensure we can review your pull request promptly please complete this template entirely. -->

<!-- Please reference the issue number here. You can replace "Fixes" with "Closes" if it makes more sense. -->
This PR makes the TorchTrainStep deterministic.

Changes proposed in this pull request:
<!-- Please list all changes/additions here. -->
- Moves the `set_seed_all` call to the beginning of the `_train` function to run before model initialization. 

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [x] I've read and followed all steps in the [Making a pull request](https://github.com/allenai/tango/blob/main/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [x] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/allenai/tango/blob/main/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [x] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.

## After submitting

<!-- Please complete this checklist AFTER submitting your PR to speed along the review process. -->
- [ ] All GitHub Actions jobs for my pull request have passed.
