### PR TITLE
Fix bugs with `Workspace` and `WandbWorkspace`, specifically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed non-deterministic behavior in `TorchTrainStep`.
 - Fixed bug in `BeakerWorkspace` where `.step_info(step)` would raise a `KeyError` if the step hasn't been registered as part of a run yet.
 - Fixed a bug in `BeakerWorkspace` where it would send too many requests to the beaker service.
+- Fixed a bug where `WandbWorkspace.step_finished()` or `.step_failed()` would crash if called
+  from a different process than `.step_starting()`.
 
 
 ## [v0.9.0](https://github.com/allenai/tango/releases/tag/v0.9.0) - 2022-06-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed non-deterministic behavior in `TorchTrainStep`.
 - Fixed bug in `BeakerWorkspace` where `.step_info(step)` would raise a `KeyError` if the step hasn't been registered as part of a run yet.
 - Fixed a bug in `BeakerWorkspace` where it would send too many requests to the beaker service.
+- Fixed a bug in how a `Step` calls `Workspace.step_starting()` and `Workspace.step_failed()`.
+  Previously, if `Workspace.step_starting()` failed, `Workspace.step_failed()` would be called,
+  which could lead to another error with the workspace, since some workspaces implicitly assume
+  that `.step_starting()` has been successfully called before `.step_failed()` is called.
 
 
 ## [v0.9.0](https://github.com/allenai/tango/releases/tag/v0.9.0) - 2022-06-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a bug in `BeakerWorkspace` where it would send too many requests to the beaker service.
 - Fixed a bug where `WandbWorkspace.step_finished()` or `.step_failed()` would crash if called
   from a different process than `.step_starting()`.
+- Fixed a bug in `WandbWorkspace.step_finished()` which led to a `RuntimeError` sometimes while
+  caching the result of a step.
 
 
 ## [v0.9.0](https://github.com/allenai/tango/releases/tag/v0.9.0) - 2022-06-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed non-deterministic behavior in `TorchTrainStep`.
 - Fixed bug in `BeakerWorkspace` where `.step_info(step)` would raise a `KeyError` if the step hasn't been registered as part of a run yet.
 - Fixed a bug in `BeakerWorkspace` where it would send too many requests to the beaker service.
-- Fixed a bug in how a `Step` calls `Workspace.step_starting()` and `Workspace.step_failed()`.
-  Previously, if `Workspace.step_starting()` failed, `Workspace.step_failed()` would be called,
-  which could lead to another error with the workspace, since some workspaces implicitly assume
-  that `.step_starting()` has been successfully called before `.step_failed()` is called.
 
 
 ## [v0.9.0](https://github.com/allenai/tango/releases/tag/v0.9.0) - 2022-06-01

--- a/tango/integrations/transformers/__init__.py
+++ b/tango/integrations/transformers/__init__.py
@@ -96,6 +96,8 @@ library under the corresponding class from the `torch <torch.html>`_ integration
             transformers::AutoModelForTokenClassification::from_pretrained
             transformers::AutoModelForVision2Seq::from_config
             transformers::AutoModelForVision2Seq::from_pretrained
+            transformers::AutoModelForVisualQuestionAnswering::from_config
+            transformers::AutoModelForVisualQuestionAnswering::from_pretrained
             transformers::AutoModelWithLMHead::from_config
             transformers::AutoModelWithLMHead::from_pretrained
 

--- a/tango/integrations/wandb/workspace.py
+++ b/tango/integrations/wandb/workspace.py
@@ -17,7 +17,7 @@ from tango.step_info import StepInfo, StepState
 from tango.workspace import Run, Workspace
 
 from .step_cache import WandbStepCache
-from .util import ArtifactKind, RunKind, check_environment
+from .util import RunKind, check_environment
 
 T = TypeVar("T")
 
@@ -224,13 +224,7 @@ class WandbWorkspace(Workspace):
                     # Caching the iterator will consume it, so we write it to the
                     # cache and then read from the cache for the return value.
                     result = self.step_cache[step]
-                result_artifact = self.cache.get_step_result_artifact(step)
-                if result_artifact is None:
-                    raise RuntimeError(f"Failed to find step result artifact for {step.unique_id}")
-                step_info.result_location = (
-                    f"{self.wandb_project_url}/artifacts/{ArtifactKind.STEP_RESULT.value}"
-                    f"/{result_artifact._sequence_name}/{result_artifact.commit_hash}"
-                )
+                step_info.result_location = self.cache.get_step_result_artifact_url(step)
             else:
                 # Create an empty artifact in order to build the DAG in W&B.
                 self.cache.create_step_result_artifact(step)

--- a/tango/step.py
+++ b/tango/step.py
@@ -358,22 +358,22 @@ class Step(Registrable, Generic[T]):
             dir_for_cleanup = TemporaryDirectory(prefix=f"{self.unique_id}-", suffix=".step_dir")
             self.work_dir_for_run = Path(dir_for_cleanup.name)
 
+        if needed_by:
+            cli_logger.info(
+                '[blue]\N{black circle} Starting step [bold]"%s"[/] (needed by "%s")...[/]',
+                self.name,
+                needed_by.name,
+            )
+        else:
+            cli_logger.info(
+                '[blue]\N{black circle} Starting step [bold]"%s"[/]...[/]',
+                self.name,
+            )
+
+        workspace.step_starting(self)
+
         try:
             kwargs = self._replace_steps_with_results(self.kwargs, workspace)
-
-            if needed_by:
-                cli_logger.info(
-                    '[blue]\N{black circle} Starting step [bold]"%s"[/] (needed by "%s")...[/]',
-                    self.name,
-                    needed_by.name,
-                )
-            else:
-                cli_logger.info(
-                    '[blue]\N{black circle} Starting step [bold]"%s"[/]...[/]',
-                    self.name,
-                )
-
-            workspace.step_starting(self)
 
             try:
                 result = self.run(**kwargs)


### PR DESCRIPTION
This fixes the issues that Ryan ran into.

There were a of things going on. First off, `Workspace.step_finished()` failed (due to an artifact not being available on W&B yet, a separate issue that's also fixed here), which led to `Workspace.step_failed()` being called, which then failed for a different reason (also fixed in this PR). Instead, I think the expected behavior here should be that Tango crashes if `Workspace.step_finished()` fails, instead of subsequently calling `Workspace.step_failed()`.