### PR TITLE
Make multicore executor output consistent with default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Improved `Step.ensure_result()` such that the step's result doesn't have to be read from the cache.
+- Fixed an issue with the output from `MulticoreExecutor` such that it's now consistent with the default `Executor` for steps that were found in the cache.
+
 ## [v0.9.1](https://github.com/allenai/tango/releases/tag/v0.9.1) - 2022-06-24
 
 ### Fixed

--- a/tango/executor.py
+++ b/tango/executor.py
@@ -23,13 +23,13 @@ class ExecutorOutput:
     """
 
     successful: Set[str]
-    """Steps which ran successfully."""
+    """Steps which ran successfully or were found in the cache."""
 
     failed: Set[str]
     """Steps that failed."""
 
     not_run: Set[str]
-    """Steps that were not executed (potentially because of failed dependencies."""
+    """Steps that were ignored (usually because of failed dependencies)."""
 
 
 class Executor:

--- a/tango/step.py
+++ b/tango/step.py
@@ -565,7 +565,18 @@ class Step(Registrable, Generic[T]):
                 "It does not make sense to call ensure_result() on a step that's not cacheable."
             )
 
-        self.result(workspace)
+        if workspace is None:
+            from tango.workspaces import default_workspace
+
+            workspace = default_workspace
+
+        if self in workspace.step_cache:
+            cli_logger.info(
+                '[green]\N{check mark} Found output for step [bold]"%s"[/] in cache...[/]',
+                self.name,
+            )
+        else:
+            self.result(workspace)
 
     def _ordered_dependencies(self) -> Iterable["Step"]:
         def dependencies_internal(o: Any) -> Iterable[Step]:


### PR DESCRIPTION
<!-- To ensure we can review your pull request promptly please complete this template entirely. -->

<!-- Please reference the issue number here. You can replace "Fixes" with "Closes" if it makes more sense. -->
Fixes #322 

Changes proposed:
- << 🐞 bug fix >> As with the default `Executor`, the `MulticoreExecutor` will now report steps that were found in the cache as successful instead of "not run".
- << 🏎 optimization >> Improved `Step.ensure_result()` so that the step's result doesn't need to be read from the cache if found.