### PR TITLE
Beaker workspace performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved `Step.ensure_result()` such that the step's result doesn't have to be read from the cache.
 - Fixed an issue with the output from `MulticoreExecutor` such that it's now consistent with the default `Executor` for steps that were found in the cache.
 - One of our error messages referred to a configuration file that no longer exists.
+- Improved performance of `BeakerWorkspace`.
 
 
 ## [v0.9.1](https://github.com/allenai/tango/releases/tag/v0.9.1) - 2022-06-24

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ pytorch-lightning>=1.6,<1.7  # needed by: pytorch_lightning
 transformers>=4.12.3         # needed by: transformers
 sentencepiece>=0.1.96        # needed by: transformers
 fairscale==0.4.6             # needed by: fairscale
-beaker-py>=1.3.0,<2.0.0      # needed by: beaker
+beaker-py>=1.6.2,<2.0.0      # needed by: beaker
 
 # sacremoses should be a dependency of transformers, but it is missing, so we add it manually.
 sacremoses                   # needed by: transformers

--- a/tango/integrations/beaker/workspace.py
+++ b/tango/integrations/beaker/workspace.py
@@ -46,7 +46,7 @@ class BeakerWorkspace(Workspace):
 
     def __init__(self, workspace: str, **kwargs):
         super().__init__()
-        self.beaker = Beaker.from_env(default_workspace=workspace, **kwargs)
+        self.beaker = Beaker.from_env(default_workspace=workspace, session=True, **kwargs)
         self.cache = BeakerStepCache(beaker=self.beaker)
         self.steps_dir = tango_cache_dir() / "beaker_workspace"
         self.locks: Dict[Step, BeakerStepLock] = {}
@@ -233,7 +233,7 @@ class BeakerWorkspace(Workspace):
         runs: Dict[str, Run] = {}
 
         with concurrent.futures.ThreadPoolExecutor(
-            max_workers=3, thread_name_prefix="BeakerWorkspace.registered_runs()-"
+            max_workers=9, thread_name_prefix="BeakerWorkspace.registered_runs()-"
         ) as executor:
             run_futures = []
             for dataset in self.beaker.workspace.datasets(
@@ -295,7 +295,7 @@ class BeakerWorkspace(Workspace):
         import concurrent.futures
 
         with concurrent.futures.ThreadPoolExecutor(
-            max_workers=3, thread_name_prefix="BeakerWorkspace._get_run_from_dataset()-"
+            max_workers=9, thread_name_prefix="BeakerWorkspace._get_run_from_dataset()-"
         ) as executor:
             step_info_futures = []
             for step_name, unique_id in steps_info.items():


### PR DESCRIPTION
<!-- To ensure we can review your pull request promptly please complete this template entirely. -->

<!-- Please reference the issue number here. You can replace "Fixes" with "Closes" if it makes more sense. -->
Fixes #326 (hopefully)

Changes proposed in this pull request:
<!-- Please list all changes/additions here. -->
- Upgrades `beaker-py` to minimum v1.6.2 in order to get this essential bug fix: https://github.com/allenai/beaker-py/commit/d3f18dcf35841e27cb7a7a1673482beb6645331c.
- Bumps the number of thread pool workers in `BeakerWorkspace`.
- Uses a single `requests.Session()` object within the Beaker client to address the "too many open files" issue (#326) and improve performance.

⚠️ We're assuming `requests.Session()` is thread safe for this use-case, even though the maintainers of `requests` don't provide any guarantees of thread safety. That said, following the discussion in https://github.com/psf/requests/issues/2766, it seems the main reason for concern is the lack of  thread safety in [`urllib3.PoolManager`](https://urllib3.readthedocs.io/en/stable/reference/urllib3.poolmanager.html) (https://github.com/psf/requests/issues/2766#issuecomment-325413752). The thread-safety issue with the pool manager seems to boil down to this: https://github.com/urllib3/urllib3/issues/1252#issuecomment-954958872. That is, when the number of hosts is greater than the number of pools. But the default number of pools is 10 (https://github.com/psf/requests/blob/main/requests/adapters.py#L66), and in our case there are only two different hosts that we connect to: beaker.org and the Beaker file heap server. So we should be okay 🤷‍♂️

If we do run into issues in the future, we should handle this in `beaker-py` but using one session per thread. We could implement this using thread-local storage similar to this: https://github.com/customerio/customerio-python/pull/77/files

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [x] I've read and followed all steps in the [Making a pull request](https://github.com/allenai/tango/blob/main/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [ ] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/allenai/tango/blob/main/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.
- [ ] If this PR fixes a bug, I've added a test that will fail without my fix.
- [ ] If this PR adds a new feature, I've added tests that sufficiently cover my new functionality.

## After submitting

<!-- Please complete this checklist AFTER submitting your PR to speed along the review process. -->
- [x] All GitHub Actions jobs for my pull request have passed.
