### PR TITLE
Add `Step.RESULT_KIND` class variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
         - ai2/general-cirrascale
     ```
     See the docs for the `BeakerExecutor` for more information on the input parameters.
+- **Step class**:
+  - Added `RESULT_KIND` class variable. Workspaces can use this to categorize step results. The `WandbWorkspace` uses this as the artifact kind, for example.
 
 ### Changed
 

--- a/tango/integrations/flax/train.py
+++ b/tango/integrations/flax/train.py
@@ -69,6 +69,7 @@ class FlaxTrainStep(Step):
     CACHEABLE = True
     FORMAT: Format = FlaxFormat()
     SKIP_ID_ARGUMENTS = {"log_every"}
+    RESULT_KIND = "model"
 
     def run(  # type: ignore[override]
         self,

--- a/tango/integrations/pytorch_lightning/train.py
+++ b/tango/integrations/pytorch_lightning/train.py
@@ -82,6 +82,7 @@ class LightningTrainStep(Step):
     DETERMINISTIC: bool = True
     CACHEABLE = True
     FORMAT: Format = TorchFormat()
+    RESULT_KIND = "model"
 
     def run(  # type: ignore[override]
         self,

--- a/tango/integrations/torch/train.py
+++ b/tango/integrations/torch/train.py
@@ -71,6 +71,7 @@ class TorchTrainStep(Step):
     CACHEABLE = True
     FORMAT: Format = TorchFormat()
     SKIP_ID_ARGUMENTS = {"distributed_port", "log_every"}
+    RESULT_KIND = "model"
 
     @property
     def resources(self) -> StepResources:

--- a/tango/integrations/wandb/step_cache.py
+++ b/tango/integrations/wandb/step_cache.py
@@ -74,9 +74,7 @@ class WandbStepCache(LocalStepCache):
         self, step: Union[Step, StepInfo]
     ) -> Optional[wandb.apis.public.Artifact]:
         try:
-            artifact_kind = (
-                step.RESULT_KIND if isinstance(step, Step) else step.result_kind
-            ) or ArtifactKind.STEP_RESULT.value
+            artifact_kind = step.result_kind or ArtifactKind.STEP_RESULT.value
             return self.wandb_client.artifact(
                 f"{self.entity}/{self.project}/{self._step_artifact_name(step)}:{step.unique_id}",
                 type=artifact_kind,

--- a/tango/integrations/wandb/step_cache.py
+++ b/tango/integrations/wandb/step_cache.py
@@ -74,9 +74,12 @@ class WandbStepCache(LocalStepCache):
         self, step: Union[Step, StepInfo]
     ) -> Optional[wandb.apis.public.Artifact]:
         try:
+            artifact_kind = (
+                step.RESULT_KIND if isinstance(step, Step) else step.result_kind
+            ) or ArtifactKind.STEP_RESULT.value
             return self.wandb_client.artifact(
                 f"{self.entity}/{self.project}/{self._step_artifact_name(step)}:{step.unique_id}",
-                type=ArtifactKind.STEP_RESULT.value,
+                type=artifact_kind,
             )
         except WandbError as exc:
             if is_missing_artifact_error(exc):

--- a/tango/step.py
+++ b/tango/step.py
@@ -155,6 +155,11 @@ class Step(Registrable, Generic[T]):
     the model output, not about how many outputs you can produce at the same time.
     """
 
+    RESULT_KIND: Optional[str] = None
+    """
+    Some workspaces use this field to differentiate between different kinds of results.
+    """
+
     _UNIQUE_ID_SUFFIX: Optional[str] = None
     """
     Used internally for testing.

--- a/tango/step.py
+++ b/tango/step.py
@@ -117,6 +117,7 @@ class Step(Registrable, Generic[T]):
       of inputs.
     :param step_resources: gives you a way to set the minimum compute resources required
       to run this step. Certain executors require this information.
+    :param step_result_kind: used to override :attr:`RESULT_KIND`.
 
     .. important::
         Overriding the unique id means that the step will always map to this value, regardless of the inputs,
@@ -173,6 +174,7 @@ class Step(Registrable, Generic[T]):
         step_config: Optional[Dict[str, Any]] = None,
         step_unique_id_override: Optional[str] = None,
         step_resources: Optional[StepResources] = None,
+        step_result_kind: Optional[str] = None,
         **kwargs,
     ):
         if self.VERSION is not None:
@@ -247,6 +249,7 @@ class Step(Registrable, Generic[T]):
         ] = None  # This is set only while the run() method runs.
         self._config = step_config
         self.step_resources = step_resources
+        self.result_kind = step_result_kind or self.RESULT_KIND
 
     @classmethod
     def massage_kwargs(cls, kwargs: Dict[str, Any]) -> Dict[str, Any]:

--- a/tango/step_info.py
+++ b/tango/step_info.py
@@ -223,6 +223,11 @@ class StepInfo(FromParams):
     Location of the result. This could be a path or a URL.
     """
 
+    result_kind: Optional[str] = None
+    """
+    The kind of result. Can be any string.
+    """
+
     config: Optional[Dict[str, Any]] = None
     """
     The raw config of the step.
@@ -316,6 +321,7 @@ class StepInfo(FromParams):
             unique_id=step.unique_id,
             step_name=step.name,
             step_class_name=step.__class__.__name__,
+            result_kind=step.RESULT_KIND,
             version=step.VERSION,
             dependencies={dep.unique_id for dep in step.dependencies},
             cacheable=step.cache_results,


### PR DESCRIPTION
Workspaces can use this field to categorize step results. The `WandbWorkspace` uses this to set the artifact kind field.

This was motivated by a discussion I had today with @cvphelps and others. For now only the W&B workspace uses this field. It allows Tango+W&B users to organize their step results in the dashboard better. And by setting the artifact kind for model outputs (like from the `TorchTrainStep`) to "model", those artifacts will automatically be added to W&B's model zoo (which is internal to our org). We might to come up with other standard result kinds besides "model", like for dataset creation/preprocessing steps.