### PR TITLE
Add `workspace_metadata` arg to `Step` class, allow changing artifact kind in W&B workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,10 +29,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     ```
     See the docs for the `BeakerExecutor` for more information on the input parameters.
 - **Step class:**
-  - Added `workspace_metadata` argument and field to the step class API.
+  - Added a metadata field to the step class API. This can be set through the class
+    variable `METADATA` or through the constructor argument `step_metadata`.
 - **Weights & Biases integration:**
   - You can now change the artifact kind for step result artifacts by adding a field
-    called "artifact_kind" to a step's ``workspace_metadata`` dictionary.
+    called "artifact_kind" to a step's metadata.
     For models, setting "artifact_kind" to "model" will add the corresponding artifact to W&B's new model zoo.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
         - ai2/general-cirrascale
     ```
     See the docs for the `BeakerExecutor` for more information on the input parameters.
+- **Step class:**
+  - Added `workspace_metadata` argument and field to the step class API.
+- **Weights & Biases integration:**
+  - You can now change the artifact kind for step result artifacts by adding a field
+    called "artifact_kind" to a step's ``workspace_metadata`` dictionary.
+    For models, setting "artifact_kind" to "model" will add the corresponding artifact to W&B's new model zoo.
 
 ### Changed
 

--- a/tango/integrations/flax/train.py
+++ b/tango/integrations/flax/train.py
@@ -69,6 +69,7 @@ class FlaxTrainStep(Step):
     CACHEABLE = True
     FORMAT: Format = FlaxFormat()
     SKIP_ID_ARGUMENTS = {"log_every"}
+    METADATA = {"artifact_kind": "model"}
 
     def run(  # type: ignore[override]
         self,

--- a/tango/integrations/pytorch_lightning/train.py
+++ b/tango/integrations/pytorch_lightning/train.py
@@ -82,6 +82,7 @@ class LightningTrainStep(Step):
     DETERMINISTIC: bool = True
     CACHEABLE = True
     FORMAT: Format = TorchFormat()
+    METADATA = {"artifact_kind": "model"}
 
     def run(  # type: ignore[override]
         self,

--- a/tango/integrations/torch/train.py
+++ b/tango/integrations/torch/train.py
@@ -71,6 +71,7 @@ class TorchTrainStep(Step):
     CACHEABLE = True
     FORMAT: Format = TorchFormat()
     SKIP_ID_ARGUMENTS = {"distributed_port", "log_every"}
+    METADATA = {"artifact_kind": "model"}
 
     @property
     def resources(self) -> StepResources:

--- a/tango/integrations/wandb/step_cache.py
+++ b/tango/integrations/wandb/step_cache.py
@@ -73,9 +73,7 @@ class WandbStepCache(LocalStepCache):
     def get_step_result_artifact(
         self, step: Union[Step, StepInfo]
     ) -> Optional[wandb.apis.public.Artifact]:
-        artifact_kind = (step.workspace_metadata or {}).get(
-            "artifact_kind", ArtifactKind.STEP_RESULT.value
-        )
+        artifact_kind = (step.metadata or {}).get("artifact_kind", ArtifactKind.STEP_RESULT.value)
         try:
             return self.wandb_client.artifact(
                 f"{self.entity}/{self.project}/{self._step_artifact_name(step)}:{step.unique_id}",

--- a/tango/integrations/wandb/step_cache.py
+++ b/tango/integrations/wandb/step_cache.py
@@ -73,10 +73,13 @@ class WandbStepCache(LocalStepCache):
     def get_step_result_artifact(
         self, step: Union[Step, StepInfo]
     ) -> Optional[wandb.apis.public.Artifact]:
+        artifact_kind = (step.workspace_metadata or {}).get(
+            "artifact_kind", ArtifactKind.STEP_RESULT.value
+        )
         try:
             return self.wandb_client.artifact(
                 f"{self.entity}/{self.project}/{self._step_artifact_name(step)}:{step.unique_id}",
-                type=ArtifactKind.STEP_RESULT.value,
+                type=artifact_kind,
             )
         except WandbError as exc:
             if is_missing_artifact_error(exc):

--- a/tango/integrations/wandb/workspace.py
+++ b/tango/integrations/wandb/workspace.py
@@ -41,6 +41,19 @@ class WandbWorkspace(Workspace):
 
     .. tip::
         Registered as a :class:`~tango.workspace.Workspace` under the name "wandb".
+
+    .. tip::
+        If you want to change the artifact kind for step result artifacts uploaded
+        to W&B, use the ``artifact_kind`` field in the ``workspace_metadata`` parameter to
+        the :class:`~tango.step.Step` class.
+
+        This can be useful if you want model objects to be added to the model zoo.
+        In that you would set ``artifact_kind = "model"``.
+        For example, your config for the step would look like this:
+
+        .. code-block::
+
+            { type: "trainer", workspace_metadata: { artifact_kind: "model" }, ... }
     """
 
     def __init__(self, project: str, entity: Optional[str] = None):

--- a/tango/integrations/wandb/workspace.py
+++ b/tango/integrations/wandb/workspace.py
@@ -44,7 +44,7 @@ class WandbWorkspace(Workspace):
 
     .. tip::
         If you want to change the artifact kind for step result artifacts uploaded
-        to W&B, use the ``artifact_kind`` field in the ``workspace_metadata`` parameter to
+        to W&B, add a field called ``artifact_kind`` to the ``metadata`` of
         the :class:`~tango.step.Step` class.
 
         This can be useful if you want model objects to be added to the model zoo.
@@ -53,7 +53,15 @@ class WandbWorkspace(Workspace):
 
         .. code-block::
 
-            { type: "trainer", workspace_metadata: { artifact_kind: "model" }, ... }
+            { type: "trainer", step_metadata: { artifact_kind: "model" }, ... }
+
+        Or just add this to the ``METADATA`` class attribute:
+
+        .. code-block::
+
+            @Step.register("trainer")
+            class TrainerStep(Step):
+                METADATA = {"artifact_kind": "model"}
     """
 
     def __init__(self, project: str, entity: Optional[str] = None):

--- a/tango/step.py
+++ b/tango/step.py
@@ -117,6 +117,8 @@ class Step(Registrable, Generic[T]):
       of inputs.
     :param step_resources: gives you a way to set the minimum compute resources required
       to run this step. Certain executors require this information.
+    :param workspace_metadata: use this to specify additional metadata for your workspace.
+      The type of metadata depends on your workspace.
 
     .. important::
         Overriding the unique id means that the step will always map to this value, regardless of the inputs,
@@ -168,6 +170,7 @@ class Step(Registrable, Generic[T]):
         step_config: Optional[Dict[str, Any]] = None,
         step_unique_id_override: Optional[str] = None,
         step_resources: Optional[StepResources] = None,
+        workspace_metadata: Optional[Dict[str, Any]] = None,
         **kwargs,
     ):
         if self.VERSION is not None:
@@ -242,6 +245,7 @@ class Step(Registrable, Generic[T]):
         ] = None  # This is set only while the run() method runs.
         self._config = step_config
         self.step_resources = step_resources
+        self.workspace_metadata = workspace_metadata
 
     @classmethod
     def massage_kwargs(cls, kwargs: Dict[str, Any]) -> Dict[str, Any]:

--- a/tango/step.py
+++ b/tango/step.py
@@ -117,8 +117,9 @@ class Step(Registrable, Generic[T]):
       of inputs.
     :param step_resources: gives you a way to set the minimum compute resources required
       to run this step. Certain executors require this information.
-    :param workspace_metadata: use this to specify additional metadata for your workspace.
-      The type of metadata depends on your workspace.
+    :param step_metadata: use this to specify additional metadata for your step.
+      This is added to the :attr:`METADATA` class variable to form the ``self.metadata`` attribute.
+      Values in ``step_metadata`` take precedence over ``METADATA``.
 
     .. important::
         Overriding the unique id means that the step will always map to this value, regardless of the inputs,
@@ -157,6 +158,11 @@ class Step(Registrable, Generic[T]):
     the model output, not about how many outputs you can produce at the same time.
     """
 
+    METADATA: Dict[str, Any] = {}
+    """
+    Arbitrary metadata about the step.
+    """
+
     _UNIQUE_ID_SUFFIX: Optional[str] = None
     """
     Used internally for testing.
@@ -170,7 +176,7 @@ class Step(Registrable, Generic[T]):
         step_config: Optional[Dict[str, Any]] = None,
         step_unique_id_override: Optional[str] = None,
         step_resources: Optional[StepResources] = None,
-        workspace_metadata: Optional[Dict[str, Any]] = None,
+        step_metadata: Optional[Dict[str, Any]] = None,
         **kwargs,
     ):
         if self.VERSION is not None:
@@ -245,7 +251,9 @@ class Step(Registrable, Generic[T]):
         ] = None  # This is set only while the run() method runs.
         self._config = step_config
         self.step_resources = step_resources
-        self.workspace_metadata = workspace_metadata
+        self.metadata = deepcopy(self.METADATA)
+        if step_metadata:
+            self.metadata.update()
 
     @classmethod
     def massage_kwargs(cls, kwargs: Dict[str, Any]) -> Dict[str, Any]:

--- a/tango/step.py
+++ b/tango/step.py
@@ -253,7 +253,7 @@ class Step(Registrable, Generic[T]):
         self.step_resources = step_resources
         self.metadata = deepcopy(self.METADATA)
         if step_metadata:
-            self.metadata.update()
+            self.metadata.update(step_metadata)
 
     @classmethod
     def massage_kwargs(cls, kwargs: Dict[str, Any]) -> Dict[str, Any]:

--- a/tango/step_info.py
+++ b/tango/step_info.py
@@ -228,6 +228,12 @@ class StepInfo(FromParams):
     The raw config of the step.
     """
 
+    workspace_metadata: Optional[Dict[str, Any]] = None
+    """
+    Workspace metadata from the step. This comes from the ``workspace_metadata``
+    argument to the :class:`~tango.step.Step` class.
+    """
+
     platform: PlatformMetadata = field(default_factory=PlatformMetadata)
     """
     The :class:`PlatformMetadata`.
@@ -320,6 +326,7 @@ class StepInfo(FromParams):
             dependencies={dep.unique_id for dep in step.dependencies},
             cacheable=step.cache_results,
             config=replace_steps_with_unique_id(config),
+            workspace_metadata=step.workspace_metadata,
             **kwargs,
         )
 

--- a/tango/step_info.py
+++ b/tango/step_info.py
@@ -228,9 +228,9 @@ class StepInfo(FromParams):
     The raw config of the step.
     """
 
-    workspace_metadata: Optional[Dict[str, Any]] = None
+    metadata: Optional[Dict[str, Any]] = None
     """
-    Workspace metadata from the step. This comes from the ``workspace_metadata``
+    Metadata from the step. This comes from the ``step_metadata``
     argument to the :class:`~tango.step.Step` class.
     """
 
@@ -326,7 +326,7 @@ class StepInfo(FromParams):
             dependencies={dep.unique_id for dep in step.dependencies},
             cacheable=step.cache_results,
             config=replace_steps_with_unique_id(config),
-            workspace_metadata=step.workspace_metadata,
+            metadata=step.metadata,
             **kwargs,
         )
 


### PR DESCRIPTION
This allows users to set the artifact kind of step result artifacts saved to Weights & Biases (using the `WandbWorkspace`) by adding a field called `artifact_kind` to the `workspace_metadata` of a step.