### PR TITLE
Auto import local Python modules when searching for registered classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Tango will now automatically search Python modules in the current working directory
+  for registered classes so that you don't always need to use the `--include-package` setting.
+
 ## [v0.12.0](https://github.com/allenai/tango/releases/tag/v0.12.0) - 2022-08-23
 
 ### Added

--- a/tango/common/registrable.py
+++ b/tango/common/registrable.py
@@ -207,21 +207,7 @@ class Registrable(FromParams):
                 if name in Registrable._registry[cls]:
                     return None
 
-        # Search all other modules in Tango.
-        for module in find_submodules(exclude={"tango.integrations*"}, recursive=False):
-            try_import(module)
-            if name in Registrable._registry[cls]:
-                return None
-
-        # Try importing all other integrations.
-        for integration_name, module in integrations.items():
-            if integration_name not in integrations_imported:
-                try_import(module)
-                integrations_imported.add(integration_name)
-                if name in Registrable._registry[cls]:
-                    return None
-
-        # Lastly, check Python files and modules in the current directory.
+        # Check Python files and modules in the current directory.
         from glob import glob
         from pathlib import Path
 
@@ -241,6 +227,20 @@ class Registrable(FromParams):
                     return None
             except:  # noqa: E722
                 continue
+
+        # Search all other modules in Tango.
+        for module in find_submodules(exclude={"tango.integrations*"}, recursive=False):
+            try_import(module)
+            if name in Registrable._registry[cls]:
+                return None
+
+        # Try importing all other integrations.
+        for integration_name, module in integrations.items():
+            if integration_name not in integrations_imported:
+                try_import(module)
+                integrations_imported.add(integration_name)
+                if name in Registrable._registry[cls]:
+                    return None
 
     @classmethod
     def resolve_class_name(

--- a/tango/common/registrable.py
+++ b/tango/common/registrable.py
@@ -221,8 +221,7 @@ class Registrable(FromParams):
                 if name in Registrable._registry[cls]:
                     return None
 
-        # Lastly, check Python files and modules in the current directory, as long as
-        # there isn't an absurd number of files.
+        # Lastly, check Python files and modules in the current directory.
         from glob import glob
         from pathlib import Path
 
@@ -235,7 +234,7 @@ class Registrable(FromParams):
             except:  # noqa: E722
                 continue
         for pyinit in glob("**/__init__.py"):
-            module = Path(pyinit).parent
+            module = str(Path(pyinit).parent)
             try:
                 try_import(module)
                 if name in Registrable._registry[cls]:

--- a/tango/common/registrable.py
+++ b/tango/common/registrable.py
@@ -213,6 +213,8 @@ class Registrable(FromParams):
 
         for pyfile in glob("*.py"):
             module = str(Path(pyfile).with_suffix(""))
+            if module == "setup":
+                continue
             try:
                 try_import(module)
                 if name in Registrable._registry[cls]:
@@ -221,6 +223,8 @@ class Registrable(FromParams):
                 continue
         for pyinit in glob("**/__init__.py"):
             module = str(Path(pyinit).parent)
+            if module == "tango" or module.startswith("test"):
+                continue
             try:
                 try_import(module)
                 if name in Registrable._registry[cls]:


### PR DESCRIPTION
<!-- To ensure we can review your pull request promptly please complete this template entirely. -->

<!-- Please reference the issue number here. You can replace "Fixes" with "Closes" if it makes more sense. -->

Changes proposed in this pull request:
<!-- Please list all changes/additions here. -->
- When Tango is looking for a registered class (like a `Step`), it will now automatically search Python modules in the current working directory after unsuccessfully looking in all of the other usual spots. As a result, users don't necessarily need to specify the `--include-package` option.

I realized the need for this when giving the Tango demo last week. All of the sudden it seemed silly that I would need to always specify `--include-package steps.py` when Tango could just assume that I would want to include the Python files in my repository.