### PR TITLE
Detailed train outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The `TorchTrainStep` now enables monitoring arbitrary model outputs during training. `TorchTrainEngine.forward_train` now returns a tuple `loss, model_outputs` for each micro batch and the list of model outputs for all micro batches in a batch is passed to the `TrainCallback.log_batch` and `TrainCallback.post_batch`.
 - Tango will now automatically search Python modules in the current working directory
   for registered classes so that you don't always need to use the `--include-package` setting.
 - The minimum supported Python version is now 3.8.

--- a/tango/integrations/torch/train.py
+++ b/tango/integrations/torch/train.py
@@ -617,7 +617,10 @@ def _train(
                     raise ValueError("nan loss encountered")
                 batch_loss += micro_batch_loss.detach().item()
                 batch_outputs.append(
-                    {key: output.detach() if isinstance(output, torch.Tensor) else output for key, output in micro_batch_outputs.items()}
+                    {
+                        key: output.detach() if isinstance(output, torch.Tensor) else output
+                        for key, output in micro_batch_outputs.items()
+                    }
                 )
 
                 # Calculate gradients.

--- a/tango/integrations/torch/train.py
+++ b/tango/integrations/torch/train.py
@@ -617,7 +617,7 @@ def _train(
                     raise ValueError("nan loss encountered")
                 batch_loss += micro_batch_loss.detach().item()
                 batch_outputs.append(
-                    {key: output.detach() for key, output in micro_batch_outputs.items()}
+                    {key: output.detach() if isinstance(output, torch.Tensor) else output for key, output in micro_batch_outputs.items()}
                 )
 
                 # Calculate gradients.

--- a/tango/integrations/torch/train_callback.py
+++ b/tango/integrations/torch/train_callback.py
@@ -163,6 +163,9 @@ class TrainCallback(Registrable):
             overall (average) batch loss across distributed workers.
 
             If you need the average loss, use :meth:`log_batch()`.
+        .. note::
+            A type of ``batch_outputs`` is a list because with gradient accumulation there will
+            more than one "micro batch" in the batch.
 
         """
         pass
@@ -178,6 +181,9 @@ class TrainCallback(Registrable):
             This callback method is not necessarily called on every step.
             The frequency depends on the value of the ``log_every`` parameter of
             :class:`TorchTrainStep`.
+        .. note::
+            A type of ``batch_outputs`` is a list because with gradient accumulation there will
+            more than one "micro batch" in the batch.
 
         """
         pass

--- a/tango/integrations/torch/train_callback.py
+++ b/tango/integrations/torch/train_callback.py
@@ -151,7 +151,9 @@ class TrainCallback(Registrable):
         """
         pass
 
-    def post_batch(self, step: int, epoch: int, batch_loss: float) -> None:
+    def post_batch(
+        self, step: int, epoch: int, batch_loss: float, batch_outputs: List[Dict[str, Any]]
+    ) -> None:
         """
         Called directly after processing a batch, but before unscaling gradients,
         clipping gradients, and taking an optimizer step.
@@ -165,7 +167,9 @@ class TrainCallback(Registrable):
         """
         pass
 
-    def log_batch(self, step: int, epoch: int, batch_loss: float) -> None:
+    def log_batch(
+        self, step: int, epoch: int, batch_loss: float, batch_outputs: List[Dict[str, Any]]
+    ) -> None:
         """
         Called after the optimizer step. Here ``batch_loss`` is the average loss across
         all distributed workers.

--- a/tango/integrations/torch/train_callback.py
+++ b/tango/integrations/torch/train_callback.py
@@ -163,6 +163,7 @@ class TrainCallback(Registrable):
             overall (average) batch loss across distributed workers.
 
             If you need the average loss, use :meth:`log_batch()`.
+
         .. note::
             A type of ``batch_outputs`` is a list because with gradient accumulation there will
             more than one "micro batch" in the batch.
@@ -181,6 +182,7 @@ class TrainCallback(Registrable):
             This callback method is not necessarily called on every step.
             The frequency depends on the value of the ``log_every`` parameter of
             :class:`TorchTrainStep`.
+
         .. note::
             A type of ``batch_outputs`` is a list because with gradient accumulation there will
             more than one "micro batch" in the batch.

--- a/tango/integrations/torch/training_engine.py
+++ b/tango/integrations/torch/training_engine.py
@@ -2,7 +2,7 @@ import os
 import tempfile
 from abc import abstractmethod
 from pathlib import Path
-from typing import Any, Dict, Optional, Union, cast
+from typing import Any, Dict, Optional, Union, cast, Tuple
 
 import torch
 import torch.distributed as dist
@@ -190,7 +190,7 @@ class TorchTrainingEngine(TrainingEngine):
 
     def forward_train(
         self, micro_batch: Dict[str, Any], micro_batch_idx: int, num_micro_batches: int
-    ) -> torch.Tensor:
+    ) -> Tuple[torch.Tensor, Dict[str, Any]]:
         if micro_batch_idx == 0:
             self.optimizer.zero_grad(set_to_none=True)
 
@@ -201,7 +201,7 @@ class TorchTrainingEngine(TrainingEngine):
             outputs = self.model(**micro_batch)
             micro_batch_loss = outputs["loss"] / num_micro_batches
 
-        return micro_batch_loss
+        return micro_batch_loss, outputs
 
     def forward_eval(self, batch: Dict[str, Any]) -> Dict[str, Any]:
         # Move tensors to right device.

--- a/tango/integrations/torch/training_engine.py
+++ b/tango/integrations/torch/training_engine.py
@@ -2,7 +2,7 @@ import os
 import tempfile
 from abc import abstractmethod
 from pathlib import Path
-from typing import Any, Dict, Optional, Union, cast, Tuple
+from typing import Any, Dict, Optional, Tuple, Union, cast
 
 import torch
 import torch.distributed as dist
@@ -63,7 +63,7 @@ class TrainingEngine(Registrable):
     @abstractmethod
     def forward_train(
         self, micro_batch: Dict[str, Any], micro_batch_idx: int, num_micro_batches: int
-    ) -> torch.Tensor:
+    ) -> Tuple[torch.Tensor, Dict[str, Any]]:
         """
         Run a forward training pass on the model.
         """

--- a/tango/integrations/wandb/torch_train_callback.py
+++ b/tango/integrations/wandb/torch_train_callback.py
@@ -175,7 +175,9 @@ class WandbTrainCallback(TrainCallback):
         if self.should_finalize_run:
             wandb.finish()
 
-    def log_batch(self, step: int, epoch: int, batch_loss: float) -> None:
+    def log_batch(
+        self, step: int, epoch: int, batch_loss: float, batch_outputs: List[Dict[str, Any]]
+    ) -> None:
         peak_gpu_mbs = peak_gpu_memory()
         if self.is_local_main_process:
             metrics = {


### PR DESCRIPTION
<!-- To ensure we can review your pull request promptly please complete this template entirely. -->


Changes proposed in this pull request:
<!-- Please list all changes/additions here. -->
- The `TorchTrainStep` now enables monitoring arbitrary model outputs during training.
- `TorchTrainEngine.forward_train` now returns a tuple `loss, model_outputs` for each micro batch.
- The list of model outputs for all micro batches in a batch is passed to the `TrainCallback.log_batch` and `TrainCallback.post_batch`.
- The documentation in the `log_batch` and `post_batch` functions  of the `TrainCallback` for why `batch_outputs` is `List[Dict[str, Any]]` is copied from the `pre_batch` function which has the same format for the `batch` input.

## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [x] I've read and followed all steps in the [Making a pull request](https://github.com/allenai/tango/blob/main/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [x] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/allenai/tango/blob/main/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.

## After submitting

<!-- Please complete this checklist AFTER submitting your PR to speed along the review process. -->
- [ ] All GitHub Actions jobs for my pull request have passed.
