### PR TITLE
Allowing indexing into step results in config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- You can now reference into a particular index of the result of another step in a config. For example: `{type: "ref", ref: "some_previous_step", key: 0}`.
+  The key field can be an integer if the result of the referenced step is a list or tuple, or a string if the result of the referenced step is a dictionary.
+
 ### Changed
 
 - Tango will now automatically search Python modules in the current working directory

--- a/tango/common/from_params.py
+++ b/tango/common/from_params.py
@@ -387,7 +387,7 @@ def construct_arg(
     if popped_params is default:
         return popped_params
 
-    from tango.step import Step, WithUnresolvedSteps
+    from tango.step import Step, StepIndexer, WithUnresolvedSteps
 
     origin = getattr(annotation, "__origin__", None)
     args = getattr(annotation, "__args__", [])
@@ -480,6 +480,18 @@ def construct_arg(
             raise ConfigurationError(f"expected key {argument_name} for {class_name}")
         else:
             return default
+
+    # For StepIndexer, we just return as-is and hope the for the best.
+    # At worst, user will get an error at runtime if they are trying to index a step
+    # result that can't be indexed.
+    # TODO (epwalsh): we could check the return type of the wrapped step here
+    # and make sure that:
+    #  1. It's an index-able object,
+    #  2. The item in the index-able object match `annotation`.
+    #
+    # But that's a lot of work and might have false negatives.
+    elif type(popped_params) == StepIndexer:
+        return popped_params
 
     # If the parameter type is a Python primitive, just pop it off
     # using the correct casting pop_xyz operation.

--- a/tango/common/from_params.py
+++ b/tango/common/from_params.py
@@ -487,9 +487,9 @@ def construct_arg(
     # TODO (epwalsh): we could check the return type of the wrapped step here
     # and make sure that:
     #  1. It's an index-able object,
-    #  2. The item in the index-able object match `annotation`.
+    #  2. The item in the index-able object matches `annotation`.
     #
-    # But that's a lot of work and might have false negatives.
+    # But that's complex and might have false negatives.
     elif type(popped_params) == StepIndexer:
         return popped_params
 

--- a/tango/common/testing/steps.py
+++ b/tango/common/testing/steps.py
@@ -3,6 +3,7 @@ import multiprocessing as mp
 import random
 import time
 from string import ascii_letters
+from typing import List
 
 import tango.common.logging as common_logging
 from tango import Step
@@ -141,6 +142,12 @@ class MultiprocessingStep(Step):
             worker.join()
 
         return True
+
+
+@Step.register("range_step")
+class RangeOutput(Step):
+    def run(self, start: int, end: int) -> List[int]:  # type: ignore
+        return list(range(start, end))
 
 
 def _worker_function(worker_id: int):

--- a/tango/common/util.py
+++ b/tango/common/util.py
@@ -269,11 +269,13 @@ def local_timezone() -> Optional[tzinfo]:
 
 
 def replace_steps_with_unique_id(o: Any):
-    from tango.step import Step
+    from tango.step import Step, StepIndexer
 
     if isinstance(o, Step):
         return {"type": "ref", "ref": o.unique_id}
-    if isinstance(o, (list, tuple, set)):
+    elif isinstance(o, StepIndexer):
+        return {"type": "ref", "ref": o.step.unique_id, "key": o.key}
+    elif isinstance(o, (list, tuple, set)):
         return o.__class__(replace_steps_with_unique_id(i) for i in o)
     elif isinstance(o, dict):
         return {key: replace_steps_with_unique_id(value) for key, value in o.items()}

--- a/tango/step.py
+++ b/tango/step.py
@@ -623,6 +623,8 @@ class Step(Registrable, Generic[T]):
             elif isinstance(o, WithUnresolvedSteps):
                 yield from dependencies_internal(o.args)
                 yield from dependencies_internal(o.kwargs)
+            elif isinstance(o, StepIndexer):
+                yield o.step
             elif isinstance(o, str):
                 return  # Confusingly, str is an Iterable of itself, resulting in infinite recursion.
             elif isinstance(o, (dict, Params)):

--- a/tango/step.py
+++ b/tango/step.py
@@ -541,8 +541,8 @@ class Step(Registrable, Generic[T]):
             return False
 
     def _replace_steps_with_results(self, o: Any, workspace: "Workspace"):
-        if isinstance(o, Step):
-            return o.result(workspace, self)
+        if isinstance(o, (Step, StepIndexer)):
+            return o.result(workspace=workspace, needed_by=self)
         elif isinstance(o, Lazy):
             return Lazy(
                 o._constructor,
@@ -701,6 +701,17 @@ class Step(Registrable, Generic[T]):
         cli_logger.error('[red]\N{ballot x} Step [bold]"%s"[/] failed[/]', self.name)
 
 
+class StepIndexer:
+    def __init__(self, step: Step, key: Union[str, int]):
+        self.step = step
+        self.key = key
+
+    def result(
+        self, workspace: Optional["Workspace"] = None, needed_by: Optional["Step"] = None
+    ) -> Any:
+        return self.step.result(workspace=workspace, needed_by=needed_by)[self.key]
+
+
 class WithUnresolvedSteps(CustomDetHash):
     """
     This is a helper class for some scenarios where steps depend on other steps.
@@ -794,8 +805,8 @@ class WithUnresolvedSteps(CustomDetHash):
         :return: A new object that's a copy of the original object, with all instances of :class:`.Step` replaced
                  with the results of the step.
         """
-        if isinstance(o, Step):
-            return o.result(workspace)
+        if isinstance(o, (Step, StepIndexer)):
+            return o.result(workspace=workspace)
         elif isinstance(o, Lazy):
             return Lazy(
                 o._constructor,

--- a/tango/step_graph.py
+++ b/tango/step_graph.py
@@ -242,6 +242,8 @@ class StepGraph(Mapping[str, Step]):
                 return {key: _to_config(value) for key, value in o.items()}
             elif isinstance(o, Step):
                 return {"type": "ref", "ref": o.name}
+            elif isinstance(o, StepIndexer):
+                return {"type": "ref", "ref": o.step.name, "key": o.key}
             elif o is not None and not isinstance(o, (bool, str, int, float)):
                 raise ValueError(o)
             return o

--- a/tests/end_to_end/test_step_indexing.py
+++ b/tests/end_to_end/test_step_indexing.py
@@ -1,0 +1,21 @@
+from tango.common.testing import TangoTestCase
+from tango.workspaces import LocalWorkspace
+
+
+class TestStepIndexing(TangoTestCase):
+    def test_step_indexing(self):
+        run_name = "run1"
+        config = {
+            "steps": {
+                "list": {"type": "range_step", "start": 0, "end": 3},
+                "added": {
+                    "type": "add_numbers",
+                    "a_number": 2,
+                    "b_number": {"type": "ref", "ref": "list", "key": 1},
+                },
+            }
+        }
+        self.run(config, name=run_name)
+        workspace = LocalWorkspace(self.TEST_DIR / "workspace")
+        result = workspace.step_result_for_run(run_name, "added")
+        assert result == 3

--- a/tests/step_graph_test.py
+++ b/tests/step_graph_test.py
@@ -1,4 +1,5 @@
 import re
+from copy import deepcopy
 from tempfile import NamedTemporaryFile
 
 import pytest
@@ -92,3 +93,16 @@ class TestStepGraph(TangoTestCase):
             step_graph.to_file(file_ref.name)
             new_step_graph = StepGraph.from_file(file_ref.name)
             assert step_graph == new_step_graph
+
+    def test_with_step_indexer(self):
+        config = {
+            "list": {"type": "range_step", "start": 0, "end": 3},
+            "added": {
+                "type": "add_numbers",
+                "a_number": 2,
+                "b_number": {"type": "ref", "ref": "list", "key": 1},
+            },
+        }
+        step_graph = StepGraph.from_params(deepcopy(config))
+        assert [s.name for s in step_graph["added"].dependencies] == ["list"]
+        assert step_graph.to_config() == config


### PR DESCRIPTION
For example, ref steps can now look like
`{type: "ref", ref: some_step, key: 0}`

<!-- To ensure we can review your pull request promptly please complete this template entirely. -->

<!-- Please reference the issue number here. You can replace "Fixes" with "Closes" if it makes more sense. -->
Closes #334 