### PR TITLE
Add `Workspace.step_result()` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added `priority` parameter to Beaker executor for setting the default task priority for Beaker jobs.
+- Added `Workspace.step_result()` method for getting a step's result from the latest
+  run.
 
 ### Changed
 

--- a/tango/workspace.py
+++ b/tango/workspace.py
@@ -242,6 +242,18 @@ class Workspace(Registrable):
         except KeyError:
             raise KeyError(f"Step result for '{step_name}' not found in workspace")
 
+    def step_result(self, step_name: str) -> Any:
+        """
+        Get the result of a step from the latest run with a step by that name.
+
+        :raises KeyError: If there is no run with the given step.
+        """
+        runs = sorted(self.registered_runs().values(), key=lambda run: run.start_date, reverse=True)
+        for run in runs:
+            if step_name in run.steps:
+                return self.step_cache[run.steps[step_name]]
+        raise KeyError(f"No step named '{step_name}' found in previous runs")
+
     def capture_logs_for_run(self, name: str) -> ContextManager[None]:
         """
         Should return a context manager that can be used to capture the logs for a run.


### PR DESCRIPTION
<!-- To ensure we can review your pull request promptly please complete this template entirely. -->

<!-- Please reference the issue number here. You can replace "Fixes" with "Closes" if it makes more sense. -->

Changes proposed in this pull request:
<!-- Please list all changes/additions here. -->
- Adds a method for getting the latest result for a given step. This is usually more convenient than `Workspace.step_result_for_run()`, which requires knowing the run name.