### PR TITLE
Update wandb artifact type

### DIFF
--- a/tango/integrations/wandb/step_cache.py
+++ b/tango/integrations/wandb/step_cache.py
@@ -91,9 +91,8 @@ class WandbStepCache(LocalStepCache):
         """
         Create an artifact for the result of a step.
         """
-        artifact = wandb.Artifact(
-            self._step_artifact_name(step), type=ArtifactKind.STEP_RESULT.value
-        )
+        artifact_kind = (step.metadata or {}).get("artifact_kind", ArtifactKind.STEP_RESULT.value)
+        artifact = wandb.Artifact(self._step_artifact_name(step), type=artifact_kind)
 
         # Add files
         if objects_dir is not None:


### PR DESCRIPTION
Fixes a bug that prevented users from specifying the output artifact type when using a wandb workspace.  The artifact type can be set from the `step.metadata['artifact_kind']`.  If that is not found, `ArtifactKind.STEP_RESULT.value` is used.  @epwalsh 




## Before submitting

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [x] I've read and followed all steps in the [Making a pull request](https://github.com/allenai/tango/blob/main/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [ ] I've updated or added any relevant docstrings following the syntax described in the
    [Writing docstrings](https://github.com/allenai/tango/blob/main/CONTRIBUTING.md#writing-docstrings) section of the `CONTRIBUTING` docs.

## After submitting

<!-- Please complete this checklist AFTER submitting your PR to speed along the review process. -->
- [ ] All GitHub Actions jobs for my pull request have passed.
