### PR TITLE
Catch all errors when attempting log record decode

### DIFF
--- a/tango/integrations/beaker/executor.py
+++ b/tango/integrations/beaker/executor.py
@@ -460,7 +460,8 @@ class BeakerExecutor(Executor):
                         # We don't need to handle logs from Tqdm since that would result in
                         # duplicate messages (those Tqdm lines get printed directly to the output as well).
                         logging.getLogger(log_record.name).handle(log_record)
-                except JSONDecodeError:
+                except:  # noqa: E722
+                    # Line must not be a log record
                     if setup_stage:
                         if line_str.startswith("[TANGO] "):
                             logger.info(

--- a/tango/integrations/beaker/executor.py
+++ b/tango/integrations/beaker/executor.py
@@ -460,7 +460,7 @@ class BeakerExecutor(Executor):
                         # We don't need to handle logs from Tqdm since that would result in
                         # duplicate messages (those Tqdm lines get printed directly to the output as well).
                         logging.getLogger(log_record.name).handle(log_record)
-                except:  # noqa: E722
+                except Exception:  # noqa: E722
                     # Line must not be a log record
                     if setup_stage:
                         if line_str.startswith("[TANGO] "):

--- a/tango/integrations/beaker/executor.py
+++ b/tango/integrations/beaker/executor.py
@@ -5,7 +5,6 @@ import threading
 import time
 import uuid
 import warnings
-from json import JSONDecodeError
 from pathlib import Path
 from typing import List, Optional, Sequence, Set, Tuple
 


### PR DESCRIPTION
Or, as @dirkgr suggested, we could just not stream the logs. But I think we should merge this either way so that we have this fix *for the record*.