### PR TITLE
Simplified beaker logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   for registered classes so that you don't always need to use the `--include-package` setting.
 - The minimum supported Python version is now 3.8.
 - Added support for PyTorch Lightning 1.7.x
+- The Beaker Executor will no-longer live-stream logs from Beaker jobs, but logs will be viewable on Beaker and more readable.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-### Fixed
-
-- Fixed a bug that did not allow a wandb artifact's type to be set from a step's metadata dictionary. 
-
 ### Added
 
 - You can now reference into a particular index of the result of another step in a config. For example: `{type: "ref", ref: "some_previous_step", key: 0}`.
@@ -33,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a bug with how the Beaker executor streams log lines from Beaker which sometimes resulted in messages missing some starting characters, and tqdm lines being duplicated.
 - Fixed a bug in the Beaker workspace where the lock dataset wouldn't be removed if the step
   was found to be in an invalid state.
+- Fixed a bug that did not allow a wandb artifact's type to be set from a step's metadata dictionary. 
 
 
 ## [v0.12.0](https://github.com/allenai/tango/releases/tag/v0.12.0) - 2022-08-23

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,8 +18,6 @@ sqlitedict
 glob2>=0.7
 petname>=2.6,<3.0
 pytz
-jsonpickle>=2.1.0,<2.3.0
-tblib>=1.7.0,<1.8.0
 
 # Protobuf is a dependency of wandb and others, but we need to pin this tightly to avoid
 # PIP dependency resolving issues.

--- a/tango/__main__.py
+++ b/tango/__main__.py
@@ -375,7 +375,6 @@ def beaker_executor_run(
     """
     This command is only used internally by the BeakerExecutor.
     """
-    from tango.common.logging import do_json_logging
     from tango.executor import Executor
 
     if include_package:
@@ -394,7 +393,6 @@ def beaker_executor_run(
 
     # Initialize logging.
     initialize_logging(log_level=log_level, enable_cli_logs=True, file_friendly_logging=True)
-    do_json_logging(f"step {step.name}")
 
     # Run step.
     executor.execute_step(step)

--- a/tango/common/logging.py
+++ b/tango/common/logging.py
@@ -89,9 +89,7 @@ import threading
 from contextlib import contextmanager
 from typing import ContextManager, Generator, List, Optional
 
-import jsonpickle
 import rich
-import tblib
 from rich.console import Console
 from rich.logging import RichHandler as _RichHandler
 from rich.padding import Padding
@@ -678,38 +676,3 @@ def file_handler(filepath: PathOrStr) -> ContextManager[None]:
         handler.addFilter(CliFilter(filter_out=not is_cli_handler))
         handlers.append(handler)
     return insert_handlers(*handlers)
-
-
-def log_record_to_json(record: logging.LogRecord) -> str:
-    attrs = record.__dict__
-    if attrs.get("exc_info") is not None:
-        # Tracebacks cannot be pickled directly, so we need help from tblib.
-        et, ev, tb = attrs["exc_info"]
-        tb_dict = tblib.Traceback(tb).to_dict()
-        attrs["exc_info"] = (et, ev, tb_dict)
-    return jsonpickle.dumps(attrs)
-
-
-def log_record_from_json(json_record: str) -> logging.LogRecord:
-    attrs = jsonpickle.loads(json_record)
-    if attrs.get("exc_info") is not None:
-        et, ev, tb_dict = attrs["exc_info"]
-        tb = tblib.Traceback.from_dict(tb_dict)
-        attrs["exc_info"] = (et, ev, tb)
-    return logging.makeLogRecord(attrs)
-
-
-class JsonHandler(logging.Handler):
-    def emit(self, record: logging.LogRecord):
-        print(log_record_to_json(record))
-
-
-def do_json_logging(prefix: str):
-    from tango.common.tqdm import logger as tqdm_logger
-
-    root_logger = logging.getLogger()
-    for logger in (root_logger, cli_logger, tqdm_logger):
-        logger.handlers.clear()
-        handler = JsonHandler()
-        handler.addFilter(PrefixLogFilter(prefix))
-        logger.addHandler(handler)

--- a/tango/executor.py
+++ b/tango/executor.py
@@ -114,13 +114,19 @@ class Executor(Registrable):
 
     def execute_sub_graph_for_step(
         self, step_graph: StepGraph, step_name: str, run_name: Optional[str] = None
-    ) -> None:
+    ) -> ExecutorOutput:
         """
         Execute the sub-graph associated with a particular step in a
         :class:`~tango.step_graph.StepGraph`.
         """
         step = step_graph[step_name]
-        self.execute_step(step)
+        try:
+            self.execute_step(step)
+        except Exception as exc:
+            log_exception(exc, logger)
+            return ExecutorOutput(successful=set(), failed={step_name}, not_run=set())
+        else:
+            return ExecutorOutput(successful={step_name}, failed=set(), not_run=set())
 
 
 Executor.register("default")(Executor)

--- a/tango/integrations/beaker/executor.py
+++ b/tango/integrations/beaker/executor.py
@@ -440,7 +440,7 @@ class BeakerExecutor(Executor):
         )
         experiment = self.beaker.experiment.create(experiment_name, spec)
         cli_logger.info(
-            '[blue]\N{black rightwards arrow} Submitted Beaker experiment [b]%s[/] for step [b]"%s"[/][/]',
+            '[blue]\N{black rightwards arrow} Submitted Beaker experiment [b]%s[/] for step [b]"%s"[/]...[/]',
             self.beaker.experiment.url(experiment),
             step_name,
         )

--- a/tango/integrations/beaker/executor.py
+++ b/tango/integrations/beaker/executor.py
@@ -449,7 +449,11 @@ class BeakerExecutor(Executor):
         try:
             self.beaker.experiment.wait_for(experiment, strict=True, quiet=True)
         except JobFailedError:
-            step.log_failure()
+            cli_logger.error(
+                '[red]\N{ballot x} Step [b]"%s"[/] failed. You can check the logs at [b]%s[/][/]',
+                step_name,
+                self.beaker.experiment.url(experiment),
+            )
             raise ExecutorError(
                 f'Beaker job for step "{step_name}" failed. '
                 f"You can check the logs at {self.beaker.experiment.url(experiment)}"

--- a/tango/integrations/beaker/executor.py
+++ b/tango/integrations/beaker/executor.py
@@ -447,7 +447,7 @@ class BeakerExecutor(Executor):
 
         # Follow the experiment and stream the logs until it completes.
         try:
-            self.beaker.experiment.wait_for(experiment, strict=True, quiet=True)
+            self.beaker.experiment.wait_for(experiment, strict=True, quiet=True, poll_interval=2.0)
         except JobFailedError:
             cli_logger.error(
                 '[red]\N{ballot x} Step [b]"%s"[/] failed. You can check the logs at [b]%s[/][/]',

--- a/tango/integrations/beaker/executor.py
+++ b/tango/integrations/beaker/executor.py
@@ -21,7 +21,7 @@ from beaker import (
     TaskResources,
     TaskSpec,
 )
-from git import Git, InvalidGitRepositoryError, Repo
+from git import Git, GitCommandError, InvalidGitRepositoryError, Repo
 
 from tango.common.exceptions import (
     CancellationError,
@@ -312,6 +312,8 @@ class BeakerExecutor(Executor):
                     "It appears you're not in a valid git repository. "
                     "The Beaker executor requires a git repository."
                 )
+            except GitCommandError:
+                pass
 
     def execute_step(self, step: Step) -> None:
         raise NotImplementedError

--- a/tango/integrations/beaker/executor.py
+++ b/tango/integrations/beaker/executor.py
@@ -289,14 +289,7 @@ class BeakerExecutor(Executor):
         # Ensure entrypoint dataset exists.
         self._ensure_entrypoint_dataset()
 
-    def execute_step(self, step: Step) -> None:
-        raise NotImplementedError
-
-    def execute_step_graph(
-        self, step_graph: StepGraph, run_name: Optional[str] = None
-    ) -> ExecutorOutput:
-        import concurrent.futures
-
+    def check_repo_state(self):
         if not self.allow_dirty:
             # Make sure repository is clean, if we're in one.
             try:
@@ -307,6 +300,16 @@ class BeakerExecutor(Executor):
                     )
             except InvalidGitRepositoryError:
                 pass
+
+    def execute_step(self, step: Step) -> None:
+        raise NotImplementedError
+
+    def execute_step_graph(
+        self, step_graph: StepGraph, run_name: Optional[str] = None
+    ) -> ExecutorOutput:
+        import concurrent.futures
+
+        self.check_repo_state()
 
         self._is_cancelled.clear()
 
@@ -413,6 +416,7 @@ class BeakerExecutor(Executor):
     def execute_sub_graph_for_step(
         self, step_graph: StepGraph, step_name: str, run_name: Optional[str] = None
     ) -> ExecutorOutput:
+        self.check_repo_state()
         try:
             self._execute_sub_graph_for_step(step_graph, step_name)
         except Exception as exc:

--- a/tango/integrations/beaker/executor.py
+++ b/tango/integrations/beaker/executor.py
@@ -423,6 +423,8 @@ class BeakerExecutor(Executor):
             )
             return
 
+        step.log_starting()
+
         # Initialize experiment and task spec.
         spec = self._build_experiment_spec(step_graph, step_name)
         self._check_if_cancelled()
@@ -433,12 +435,10 @@ class BeakerExecutor(Executor):
         )
         experiment = self.beaker.experiment.create(experiment_name, spec)
         cli_logger.info(
-            '[blue]\N{black rightwards arrow} Submitted Beaker experiment [b]%s[/] for step [b]"%s"[/] (%s)[/]',
+            '[blue]\N{black rightwards arrow} Submitted Beaker experiment [b]%s[/] for step [b]"%s"[/][/]',
             self.beaker.experiment.url(experiment),
             step_name,
-            step.unique_id,
         )
-        step.log_starting()
 
         # Follow the experiment and stream the logs until it completes.
         try:
@@ -600,7 +600,13 @@ class BeakerExecutor(Executor):
         except ValueError:
             raise ExecutorError("BeakerExecutor requires a git repository with a GitHub remote.")
         git_ref = git.commit
-        logger.info("Using GitHub repository '%s/%s' @ %s", github_account, github_repo, git_ref)
+        cli_logger.info(
+            '[blue]\N{black rightwards arrow} Using source code from [b]https://github.com/%s/%s/commit/%s[/] for step [b]"%s"[/][/]',
+            github_account,
+            github_repo,
+            git_ref,
+            step_name,
+        )
         self._check_if_cancelled()
 
         # Ensure dataset with the entrypoint script exists and get it.

--- a/tango/integrations/beaker/executor.py
+++ b/tango/integrations/beaker/executor.py
@@ -610,7 +610,8 @@ class BeakerExecutor(Executor):
             raise ExecutorError("BeakerExecutor requires a git repository with a GitHub remote.")
         git_ref = git.commit
         cli_logger.info(
-            '[blue]\N{black rightwards arrow} Using source code from [b]https://github.com/%s/%s/commit/%s[/] for step [b]"%s"[/][/]',
+            "[blue]\N{black rightwards arrow} Using source code from "
+            '[b]https://github.com/%s/%s/commit/%s[/] for step [b]"%s"[/][/]',
             github_account,
             github_repo,
             git_ref,

--- a/tango/step.py
+++ b/tango/step.py
@@ -698,8 +698,9 @@ class Step(Registrable, Generic[T]):
                 self.name,
             )
 
-    def log_failure(self, exception: BaseException) -> None:
-        log_exception(exception, logger=self.logger)
+    def log_failure(self, exception: Optional[BaseException] = None) -> None:
+        if exception is not None:
+            log_exception(exception, logger=self.logger)
         cli_logger.error('[red]\N{ballot x} Step [bold]"%s"[/] failed[/]', self.name)
 
 


### PR DESCRIPTION
Changes proposed:
- Don't stream logs from Beaker jobs. As a result I think the Beaker executor is more robust now because the logic for doing that was very complex. And this also means we don't need to do JSON logging within Beaker, so those logs will be human-readable.
- Closes #381 

Now the local output will look like this:

![image](https://user-images.githubusercontent.com/8812459/188238461-766afb2f-9187-4e26-879c-d6b5d6060cbe.png)
