### PR TITLE
Fix bug with `StepInfo.from_params()`, canceling `BeakerExecutor`, reserve "ref" name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a bug with the internal scheduling logic of the `BeakerExecutor` which
   could delay submitting some steps in parallel.
 - Fixed a bug where creating a `StepInfo` object from params might result in unnecessary imports.
+- Fixed a bug where canceling the Beaker executor might not work properly.
 
 ## [v0.13.0](https://github.com/allenai/tango/releases/tag/v0.13.0) - 2022-09-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Made `BeakerExecutor` more robust to connection, timeout, SSL, and other recoverable HTTP errors.
 - Fixed a bug with the internal scheduling logic of the `BeakerExecutor` which
   could delay submitting some steps in parallel.
+- Fixed a bug where creating a `StepInfo` object from params might result in unnecessary imports.
 
 ## [v0.13.0](https://github.com/allenai/tango/releases/tag/v0.13.0) - 2022-09-07
 

--- a/tango/common/registrable.py
+++ b/tango/common/registrable.py
@@ -123,6 +123,13 @@ class Registrable(FromParams):
                     ...  # construct some_params from files
                     return cls(some_params)
         """
+        from tango.step import Step
+
+        if cls == Step and name == "ref":
+            raise ConfigurationError(
+                "You cannot use the name 'ref' to register a step. This name is reserved."
+            )
+
         registry = Registrable._registry[cls]
 
         def add_subclass_to_registry(subclass: Type[_T]) -> Type[_T]:
@@ -178,7 +185,12 @@ class Registrable(FromParams):
         """
         Search for and import modules where ``name`` might be registered.
         """
+        from tango.step import Step
+
         if could_be_class_name(name) or name in Registrable._registry[cls]:
+            return None
+
+        if cls == Step and name == "ref":
             return None
 
         def try_import(module):

--- a/tango/common/registrable.py
+++ b/tango/common/registrable.py
@@ -146,9 +146,9 @@ class Registrable(FromParams):
                     return already_in_use_for
                 elif exist_ok:
                     message = (
-                        f"Registering {_fullname(subclass)} as a {_fullname(cls)} under the name {name} overwrites "
-                        f"existing entry {_fullname(already_in_use_for)}, which is fine because you said "
-                        "exist_ok=True."
+                        f"Registering {_fullname(subclass)} as a {_fullname(cls)} under the name {name} "
+                        f"overwrites existing entry {_fullname(already_in_use_for)}, which is fine because "
+                        "you said exist_ok=True."
                     )
                     logger.info(message)
                 else:

--- a/tango/integrations/beaker/workspace.py
+++ b/tango/integrations/beaker/workspace.py
@@ -217,7 +217,7 @@ class BeakerWorkspace(Workspace):
 
         # Collect step info.
         with concurrent.futures.ThreadPoolExecutor(
-            max_workers=9, thread_name_prefix="BeakerWorkspace.register_run()-"
+            thread_name_prefix="BeakerWorkspace.register_run()-"
         ) as executor:
             step_info_futures = []
             for step in all_steps:
@@ -226,6 +226,7 @@ class BeakerWorkspace(Workspace):
                 step_info_futures.append(executor.submit(self.step_info, step))
             for future in concurrent.futures.as_completed(step_info_futures):
                 step_info = future.result()
+                assert step_info.step_name is not None
                 steps[step_info.step_name] = step_info
                 run_data[step_info.step_name] = step_info.unique_id
 

--- a/tango/step_info.py
+++ b/tango/step_info.py
@@ -301,7 +301,7 @@ class StepInfo(FromParams):
 
         :param json_dict: A dictionary representation, such as the one produced by :meth:`to_json_dict()`.
         """
-        return cls.from_params(
+        step_info = cls.from_params(
             {
                 k: (
                     datetime.strptime(v, "%Y-%m-%dT%H:%M:%S").replace(tzinfo=pytz.utc)
@@ -309,8 +309,11 @@ class StepInfo(FromParams):
                     else v
                 )
                 for k, v in json_dict.items()
+                if k != "config"
             }
         )
+        step_info.config = json_dict.get("config")
+        return step_info
 
     @classmethod
     def new_from_step(cls, step: Step, **kwargs) -> "StepInfo":

--- a/tests/common/registrable_test.py
+++ b/tests/common/registrable_test.py
@@ -3,6 +3,7 @@ import pytest
 from tango.common.exceptions import ConfigurationError
 from tango.common.registrable import Registrable
 from tango.common.testing import TangoTestCase
+from tango.step import Step
 
 
 class TestRegistrable(TangoTestCase):
@@ -39,3 +40,10 @@ class TestRegistrable(TangoTestCase):
         with pytest.raises(ConfigurationError) as exc:
             MockBaseClass.by_name("mock_1")
             assert "did you mean 'mock-1'?" in str(exc.value)
+
+    def test_registering_step_by_reserved_name(self):
+        with pytest.raises(ConfigurationError, match="cannot use the name 'ref'"):
+
+            @Step.register("ref")
+            class BadStep(Step):
+                pass


### PR DESCRIPTION
- Fixes another bug with `StepInfo.from_params()` which would result in `from_params` / `Registrable` trying to instantiate things they shouldn't be. Normally this isn't a big deal because the in the end everything gets created how it should, but it slows things down substantially when you have a large step graph. This is related to #344.
- Fixes a bug with the `BeakerExecutor` where hitting CTRL-C doesn't work as expected. It just hangs instead of stopping the experiments that were already submitted. For some reason I only ran into this bug when running a large step graph.
- Makes the `BeakerWorkspace` more robust to finding step info data in an invalid state, which can happen quite often when Beaker jobs are stopped prematurely.
- 🚧  Safety improvement that I thought of when I was fixing the first bug: We should make sure "ref" is a reserved name that can't be used to register a step.