### PR TITLE
Make `BeakerStepLock` more robust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Made `BeakerExecutor` more robust to connection, timeout, SSL, and other recoverable HTTP errors.
+- Made the `BeakerStepLock` more robust, and as a result `BeakerWorkspace` is more
+  robust and should require less manual intervention for locks in a bad state.
 - Fixed a bug with the internal scheduling logic of the `BeakerExecutor` which
   could delay submitting some steps in parallel.
 - Fixed a bug where creating a `StepInfo` object from params might result in unnecessary imports.

--- a/tango/integrations/beaker/common.py
+++ b/tango/integrations/beaker/common.py
@@ -1,9 +1,20 @@
+import atexit
+import json
 import logging
+import tempfile
 import time
 import urllib.parse
-from typing import Optional, Union
+from pathlib import Path
+from typing import Any, Dict, Optional, Union
 
-from beaker import Beaker, Dataset, DatasetConflict, DatasetNotFound
+from beaker import (
+    Beaker,
+    Dataset,
+    DatasetConflict,
+    DatasetNotFound,
+    Experiment,
+    ExperimentNotFound,
+)
 
 from tango.step import Step
 from tango.step_info import StepInfo
@@ -48,12 +59,28 @@ def dataset_url(workspace_url: str, dataset_name: str) -> str:
 
 
 class BeakerStepLock:
-    def __init__(self, beaker: Beaker, step: Union[str, StepInfo, Step], **kwargs):
+    METADATA_FNAME = "metadata.json"
+
+    def __init__(
+        self,
+        beaker: Beaker,
+        step: Union[str, StepInfo, Step],
+        current_beaker_experiment: Optional[Experiment] = None,
+    ):
         self._beaker = beaker
         self._step_id = step if isinstance(step, str) else step.unique_id
         self._lock_dataset_name = step_lock_dataset_name(step)
         self._lock_dataset: Optional[Dataset] = None
+        self._current_beaker_experiment = current_beaker_experiment
         self.lock_dataset_url = dataset_url(beaker.workspace.url(), self._lock_dataset_name)
+
+    @property
+    def metadata(self) -> Dict[str, Any]:
+        return {
+            "beaker_experiment": None
+            if not self._current_beaker_experiment
+            else self._current_beaker_experiment.id
+        }
 
     def acquire(self, timeout=None, poll_interval: float = 2.0, log_interval: float = 30.0) -> None:
         if self._lock_dataset is not None:
@@ -65,7 +92,41 @@ class BeakerStepLock:
                 self._lock_dataset = self._beaker.dataset.create(
                     self._lock_dataset_name, commit=False
                 )
+
+                atexit.register(self.release)
+
+                # Write metadata.
+                with tempfile.TemporaryDirectory() as tmp_dir_name:
+                    tmp_dir = Path(tmp_dir_name)
+                    metadata_path = tmp_dir / self.METADATA_FNAME
+                    with open(metadata_path, "w") as f:
+                        json.dump(self.metadata, f)
+                    self._beaker.dataset.sync(self._lock_dataset, metadata_path, quiet=True)
             except DatasetConflict:
+                # Check if existing lock was created from a Beaker experiment.
+                # If it was, and the experiment is no-longer running, we can safely
+                # delete it.
+                try:
+                    metadata_bytes = self._beaker.dataset.get_file(
+                        self._lock_dataset_name, self.METADATA_FNAME, quiet=True
+                    )
+                    metadata = json.loads(metadata_bytes)
+                    experiment_id = metadata.get("beaker_experiment")
+                    if experiment_id is not None:
+                        try:
+                            experiment = self._beaker.experiment.get(experiment_id)
+                            job = self._beaker.experiment.latest_job(experiment)
+                            if job is not None and job.is_done:
+                                self._beaker.dataset.delete(self._lock_dataset_name)
+                                continue
+                        except ExperimentNotFound:
+                            self._beaker.dataset.delete(self._lock_dataset_name)
+                            continue
+                except DatasetNotFound:
+                    continue
+                except Exception:
+                    pass
+
                 if last_logged is None or last_logged - start >= log_interval:
                     logger.warning(
                         "Waiting to acquire lock dataset for step '%s':\n\n%s\n\n"

--- a/tango/integrations/beaker/common.py
+++ b/tango/integrations/beaker/common.py
@@ -156,6 +156,7 @@ class BeakerStepLock:
                 # Dataset must have been manually deleted.
                 pass
             self._lock_dataset = None
+            atexit.unregister(self.release)
 
     def __del__(self):
         self.release()


### PR DESCRIPTION
Makes the `BeakerStepLock` more robust to being left in a bad state, and as a result the `BeakerWorkspace` is more robust.

In particular, there are two changes here that make this work:
1. The `BeakerStepLock` is made aware of the Beaker experiment that last acquired the lock (if there was one). So if the lock is left in a bad state by that Beaker experiment, another process trying to acquire the lock can just check the state of the experiment.
2. The `BeakerStepLock` registers an `atexit` hook to call `release()`. This makes it way less likely that the lock will be left in a bad state.