### PR TITLE
Make GPU CI tests preemptible on Beaker

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -273,6 +273,7 @@ jobs:
                   beaker: ${{ env.BEAKER_IMAGE }}
                 context:
                   cluster: ${{ env.BEAKER_DEFAULT_CLUSTER }}
+                  priority: preemptible
                 resources:
                   gpuCount: 2
                 envVars:


### PR DESCRIPTION
As of https://github.com/allenai/beaker-run-action/pull/37 this should work seamlessly, and will make us better Beaker citizens.