### PR TITLE
Add warning when steps can't be run yet, bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a bug where creating a `StepInfo` object from params might result in unnecessary imports.
 - Fixed a bug where canceling the Beaker executor might not work properly.
 - Fixed a bug where the trainer trains too much when `train_epochs` is set and you're using gradient accumulation.
+- Fixed how the results of uncacheable steps are displayed by `tango run`.
 
 ## [v0.13.0](https://github.com/allenai/tango/releases/tag/v0.13.0) - 2022-09-07
 

--- a/tango/__main__.py
+++ b/tango/__main__.py
@@ -872,6 +872,8 @@ def _display_run_results(
             execution_metadata = executor_output.successful[step_name]
             if execution_metadata.result_location is not None:
                 result_str = f"[cyan]{execution_metadata.result_location}[/]"
+            elif execution_metadata.logs_location is not None:
+                result_str = f"[cyan]{execution_metadata.logs_location}[/]"
         else:
             continue
 

--- a/tango/executor.py
+++ b/tango/executor.py
@@ -144,7 +144,9 @@ class Executor(Registrable):
             return ExecutorOutput(
                 successful={
                     step_name: ExecutionMetadata(
-                        result_location=self.workspace.step_info(step).result_location
+                        result_location=None
+                        if not step.cache_results
+                        else self.workspace.step_info(step).result_location
                     )
                 }
             )

--- a/tango/executors/multicore_executor.py
+++ b/tango/executors/multicore_executor.py
@@ -157,8 +157,11 @@ class MulticoreExecutor(Executor):
                 _running.pop(step_name)
 
             for step_name in done:
+                step = step_graph[step_name]
                 _successful[step_name] = ExecutionMetadata(
-                    result_location=self.workspace.step_info(step_graph[step_name]).result_location
+                    result_location=None
+                    if not step.cache_results
+                    else self.workspace.step_info(step).result_location
                 )
 
             for step_name in errors:

--- a/tango/integrations/beaker/executor.py
+++ b/tango/integrations/beaker/executor.py
@@ -544,7 +544,9 @@ class BeakerExecutor(Executor):
                     exc = future.exception()
                     if exc is None:
                         successful[step_name] = ExecutionMetadata(
-                            result_location=self.workspace.step_info(step).result_location,
+                            result_location=None
+                            if not step.cache_results
+                            else self.workspace.step_info(step).result_location,
                             logs_location=future.result(),
                         )
                         steps_left_to_run.discard(step)
@@ -634,13 +636,14 @@ class BeakerExecutor(Executor):
         self.check_repo_state()
         while True:
             try:
+                step = step_graph[step_name]
                 experiment_url = self._execute_sub_graph_for_step(step_graph, step_name)
                 return ExecutorOutput(
                     successful={
                         step_name: ExecutionMetadata(
-                            result_location=self.workspace.step_info(
-                                step_graph[step_name]
-                            ).result_location,
+                            result_location=None
+                            if not step.cache_results
+                            else self.workspace.step_info(step).result_location,
                             logs_location=experiment_url,
                         )
                     }


### PR DESCRIPTION
So people know why the executor isn't doing anything. Also fixes running a single step with the Beaker executor by handling the `ResourceAssignmentError`, and fixes the step result location for uncacheable steps.