### PR TITLE
Ensure log lines get soft-wrapped so links are always clickable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Long log lines will be soft-wrapped to ensure that links are clickable.
+
 ## [v0.14.0](https://github.com/allenai/tango/releases/tag/v0.14.0) - 2022-09-20
 
 ### Added

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -26,11 +26,11 @@ class TestRun(TangoTestCase):
             parts = re.split(r"(DEBUG|INFO|WARNING|ERROR|CRITICAL)\s+", line)
             if len(parts) >= 3:
                 line = "".join(parts[2:])
+                line = re.sub(r"\s+[^ ]+$", "", line)
             elif len(parts) == 1:
                 line = parts[0]
             else:
                 raise ValueError(str(parts))
-            line = re.sub(r"\s+[^ ]+$", "", line)
             if line:
                 out.append(line.strip())
         return out


### PR DESCRIPTION
<!-- To ensure we can review your pull request promptly please complete this template entirely. -->

<!-- Please reference the issue number here. You can replace "Fixes" with "Closes" if it makes more sense. -->
Fixes #411 by implementing our own `RichHandler` based on https://github.com/Textualize/rich/blob/master/rich/logging.py

The code in our `RichHandler` is basically the same, except that instead of printing a `Table` object it just prints a `Group` object so that wrapping is done how we like it:

![image](https://user-images.githubusercontent.com/8812459/191583394-5ed01550-d0f9-4c97-935e-0629f6c78447.png)

As you can see in this screenshot, I also made another change. The paths on the right side of the screen are now more informative. Instead of just showing the filename (which can be very ambiguous) we print a path relative to the directory where that module was found.