### PR TITLE
Minor improvements to `BeakerExecutor` internals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- `beaker-py >= 1.10` required.
+
 ### Fixed
 
 - Long log lines will be soft-wrapped to ensure that links are clickable.

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,7 @@ pytorch-lightning>=1.6,<1.8  # needed by: pytorch_lightning
 transformers>=4.12.3         # needed by: transformers
 sentencepiece==0.1.97        # needed by: transformers
 fairscale==0.4.9             # needed by: fairscale
-beaker-py>=1.8.0,<2.0.0      # needed by: beaker
+beaker-py>=1.10.0,<2.0.0      # needed by: beaker
 
 # sacremoses should be a dependency of transformers, but it is missing, so we add it manually.
 sacremoses                   # needed by: transformers

--- a/tango/integrations/beaker/common.py
+++ b/tango/integrations/beaker/common.py
@@ -31,6 +31,13 @@ class Constants:
     ENTRYPOINT_DATASET_PREFIX = "tango-entrypoint-"
     STEP_GRAPH_DATASET_PREFIX = "tango-step-graph-"
     STEP_EXPERIMENT_PREFIX = "tango-step-"
+    STEP_GRAPH_FILENAME = "config.json"
+    GITHUB_TOKEN_SECRET_NAME: str = "TANGO_GITHUB_TOKEN"
+    BEAKER_TOKEN_SECRET_NAME: str = "BEAKER_TOKEN"
+    RESULTS_DIR: str = "/tango/output"
+    ENTRYPOINT_DIR: str = "/tango/entrypoint"
+    ENTRYPOINT_FILENAME: str = "entrypoint.sh"
+    INPUT_DIR: str = "/tango/input"
 
 
 def step_dataset_name(step: Union[str, StepInfo, Step]) -> str:

--- a/tango/integrations/beaker/workspace.py
+++ b/tango/integrations/beaker/workspace.py
@@ -264,12 +264,12 @@ class BeakerWorkspace(Workspace):
                 steps[step_info.step_name] = step_info
                 run_data[step_info.step_name] = step_info.unique_id
 
-        # Create Beaker dataset for run.
-        with tempfile.TemporaryDirectory() as tmp_dir_name:
-            tmp_dir = Path(tmp_dir_name)
-            with open(tmp_dir / Constants.RUN_DATA_FNAME, "w") as f:
-                json.dump(run_data, f)
-            self.beaker.dataset.sync(run_dataset, tmp_dir / Constants.RUN_DATA_FNAME, quiet=True)
+        # Upload run data to dataset.
+        # NOTE: We don't commit the dataset here since we'll need to upload the logs file
+        # after the run.
+        self.beaker.dataset.upload(
+            run_dataset, json.dumps(run_data).encode(), Constants.RUN_DATA_FNAME, quiet=True
+        )
 
         return Run(name=cast(str, name), steps=steps, start_date=run_dataset.created)
 
@@ -344,7 +344,7 @@ class BeakerWorkspace(Workspace):
             max_workers=9, thread_name_prefix="BeakerWorkspace._get_run_from_dataset()-"
         ) as executor:
             step_info_futures = []
-            for step_name, unique_id in steps_info.items():
+            for unique_id in steps_info.values():
                 step_info_futures.append(executor.submit(self.step_info, unique_id))
             for future in concurrent.futures.as_completed(step_info_futures):
                 step_info = future.result()
@@ -362,11 +362,9 @@ class BeakerWorkspace(Workspace):
         except DatasetConflict:
             step_info_dataset = self.beaker.dataset.get(dataset_name)
 
-        with tempfile.TemporaryDirectory() as tmp_dir_name:
-            tmp_dir = Path(tmp_dir_name)
-
-            # Save step info.
-            step_info_path = tmp_dir / Constants.STEP_INFO_FNAME
-            with open(step_info_path, "w") as f:
-                json.dump(step_info.to_json_dict(), f)
-            self.beaker.dataset.sync(step_info_dataset, step_info_path, quiet=True)
+        self.beaker.dataset.upload(
+            step_info_dataset,
+            json.dumps(step_info.to_json_dict()).encode(),
+            Constants.STEP_INFO_FNAME,
+            quiet=True,
+        )


### PR DESCRIPTION
Makes use of new `Beaker.dataset.upload()` method where we can upload the bytes of an object directly instead of having to write them to a temporary file first.