### PR TITLE
Improve error handling for step state edge case

### DIFF
--- a/tango/step.py
+++ b/tango/step.py
@@ -589,10 +589,15 @@ class Step(Registrable, Generic[T]):
             try:
                 return self._run_with_work_dir(workspace, needed_by=needed_by)
             except StepStateError as exc:
-                if exc.step_state != StepState.COMPLETED:
+                if exc.step_state != StepState.COMPLETED or not self.cache_results:
                     raise
-                # Step has been completed (and cached) by a different process, so we
-                # do nothing here and pull the result from the cache below.
+                elif self not in workspace.step_cache:
+                    raise StepStateError(
+                        self, exc.step_state, "because it's not found in the cache"
+                    )
+                else:
+                    # Step has been completed (and cached) by a different process, so we're done.
+                    pass
 
         self.log_cache_hit(needed_by=needed_by)
         return workspace.step_cache[self]


### PR DESCRIPTION
I ran into this issue where the step failed while trying to cache the result because the machine ran out of space, and so marking the step as failed also failed. Hence the step info was left as being marked "COMPLETE", but the step's result wasn't in the cache. So when I ran this step again, I got a weird error that I had to debug in order to figure out what was going on. This will catch those situations and provide a more helpful error message.