### PR TITLE
Fix bug with Beaker executor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a bug where some workspaces could be left in a bad state if a step's `Format` failed to serialize the step's result in `Workspace.step_finished()`.
 - Sometimes functions and methods end up as arguments to steps, which means we have to hash them. Instead of taking
   a hash of the function, we now take a hash of the function's module and name.
+- Fixed a bug with the Beaker executor where it would hang at the end of a run if a step failed that is a dependency of another step.
 
 ## [v0.14.0](https://github.com/allenai/tango/releases/tag/v0.14.0) - 2022-09-20
 

--- a/tango/integrations/beaker/executor.py
+++ b/tango/integrations/beaker/executor.py
@@ -567,24 +567,24 @@ class BeakerExecutor(Executor):
             if now - last_progress_update >= 60 * 2:
                 last_progress_update = now
 
-                waiting_on = [
+                waiting_for = [
                     step_name
                     for step_name in submitted_steps
                     if step_name not in failed and step_name not in successful
                 ]
-                if len(waiting_on) > 5:
+                if len(waiting_for) > 5:
                     logger.info(
                         "Waiting on %d running steps...",
-                        len(waiting_on),
+                        len(waiting_for),
                     )
-                elif len(waiting_on) > 1:
+                elif len(waiting_for) > 1:
                     logger.info(
                         "Waiting on %d running steps (%s)...",
-                        len(waiting_on),
-                        list(waiting_on),
+                        len(waiting_for),
+                        list(waiting_for),
                     )
-                elif len(waiting_on) == 1:
-                    logger.info("Waiting on 1 running step ('%s')...", list(waiting_on)[0])
+                elif len(waiting_for) == 1:
+                    logger.info("Waiting on 1 running step ('%s')...", list(waiting_for)[0])
 
                 still_to_run = [
                     step.name for step in steps_left_to_run if step.name not in submitted_steps

--- a/tango/integrations/beaker/executor.py
+++ b/tango/integrations/beaker/executor.py
@@ -515,6 +515,7 @@ class BeakerExecutor(Executor):
                                 # A dependency failed or can't be run, so this step can't be run.
                                 not_run[step_name] = ExecutionMetadata()
                                 steps_to_run.discard(step_name)
+                                steps_left_to_run.discard(step)
                             break
                     else:
                         # Dependencies are OK, so we can run this step now.
@@ -557,6 +558,51 @@ class BeakerExecutor(Executor):
 
             return future_done_callback
 
+        last_progress_update = time.monotonic()
+
+        def log_progress():
+            nonlocal last_progress_update
+
+            now = time.monotonic()
+            if now - last_progress_update >= 60 * 2:
+                last_progress_update = now
+
+                waiting_on = [
+                    step_name
+                    for step_name in submitted_steps
+                    if step_name not in failed and step_name not in successful
+                ]
+                if len(waiting_on) > 5:
+                    logger.info(
+                        "Waiting on %d running steps...",
+                        len(waiting_on),
+                    )
+                elif len(waiting_on) > 1:
+                    logger.info(
+                        "Waiting on %d running steps (%s)...",
+                        len(waiting_on),
+                        list(waiting_on),
+                    )
+                elif len(waiting_on) == 1:
+                    logger.info("Waiting on 1 running step ('%s')...", list(waiting_on)[0])
+
+                still_to_run = [
+                    step.name for step in steps_left_to_run if step.name not in submitted_steps
+                ]
+                if len(still_to_run) > 5:
+                    logger.info(
+                        "Still waiting to submit %d more steps...",
+                        len(still_to_run),
+                    )
+                elif len(still_to_run) > 1:
+                    logger.info(
+                        "Still waiting to submit %d more steps (%s)...",
+                        len(still_to_run),
+                        still_to_run,
+                    )
+                elif len(still_to_run) == 1:
+                    logger.info("Still waiting to submit 1 more step ('%s')...", still_to_run)
+
         update_steps_to_run()
 
         try:
@@ -589,6 +635,8 @@ class BeakerExecutor(Executor):
 
                     # Update the step queue.
                     update_steps_to_run()
+
+                    log_progress()
         except (KeyboardInterrupt, CancellationError):
             if step_futures:
                 cli_logger.warning("Received interrupt, canceling steps...")

--- a/tango/integrations/beaker/executor.py
+++ b/tango/integrations/beaker/executor.py
@@ -574,17 +574,17 @@ class BeakerExecutor(Executor):
                 ]
                 if len(waiting_for) > 5:
                     logger.info(
-                        "Waiting on %d running steps...",
+                        "Waiting for %d running steps...",
                         len(waiting_for),
                     )
                 elif len(waiting_for) > 1:
                     logger.info(
-                        "Waiting on %d running steps (%s)...",
+                        "Waiting for %d running steps (%s)...",
                         len(waiting_for),
                         list(waiting_for),
                     )
                 elif len(waiting_for) == 1:
-                    logger.info("Waiting on 1 running step ('%s')...", list(waiting_for)[0])
+                    logger.info("Waiting for 1 running step ('%s')...", list(waiting_for)[0])
 
                 still_to_run = [
                     step.name for step in steps_left_to_run if step.name not in submitted_steps


### PR DESCRIPTION
The Beaker executor would hang at the end of a run if a step failed that was a dependency of another step.

This also makes the Beaker executor periodically print out updates so you know how many and which steps it's still waiting on.