### PR TITLE
Use separate local cache dirs for each workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `LightningTrainStep` now can take a `Lazy` model object which results in a gauranteed deterministic hash.
+- Fixed issue where remote `Workspace` implementations like `WandbWorkspace` and `BeakerWorkspace` would use the same local cache regardless of the W&B / Beaker workspace
+  being used.
 - Fixed bug with `TorchEvalStep` when constructing callbacks.
 - Fixed some import error issues caused when an integration is not installed.
 

--- a/tango/common/util.py
+++ b/tango/common/util.py
@@ -187,7 +187,7 @@ def filename_is_safe(filename: str) -> bool:
 
 
 def make_safe_filename(name: str) -> str:
-    name = name.replace(" ", "-")
+    name = name.replace(" ", "-").replace("/", "--")
     return "".join(c for c in name if c in SAFE_FILENAME_CHARS)
 
 

--- a/tango/common/util.py
+++ b/tango/common/util.py
@@ -186,6 +186,11 @@ def filename_is_safe(filename: str) -> bool:
     return all(c in SAFE_FILENAME_CHARS for c in filename)
 
 
+def make_safe_filename(name: str) -> str:
+    name = name.replace(" ", "-")
+    return "".join(c for c in name if c in SAFE_FILENAME_CHARS)
+
+
 def could_be_class_name(name: str) -> bool:
     if "." in name and not name.endswith("."):
         return all([_is_valid_python_name(part) for part in name.split(".")])

--- a/tango/common/util.py
+++ b/tango/common/util.py
@@ -187,8 +187,14 @@ def filename_is_safe(filename: str) -> bool:
 
 
 def make_safe_filename(name: str) -> str:
-    name = name.replace(" ", "-").replace("/", "--")
-    return "".join(c for c in name if c in SAFE_FILENAME_CHARS)
+    if filename_is_safe(name):
+        return name
+    else:
+        from tango.common.det_hash import det_hash
+
+        name_hash = det_hash(name)
+        name = name.replace(" ", "-").replace("/", "--")
+        return "".join(c for c in name if c in SAFE_FILENAME_CHARS) + f"-{name_hash[:7]}"
 
 
 def could_be_class_name(name: str) -> bool:

--- a/tango/integrations/beaker/executor.py
+++ b/tango/integrations/beaker/executor.py
@@ -601,7 +601,7 @@ class BeakerExecutor(Executor):
                         still_to_run,
                     )
                 elif len(still_to_run) == 1:
-                    logger.info("Still waiting to submit 1 more step ('%s')...", still_to_run)
+                    logger.info("Still waiting to submit 1 more step ('%s')...", still_to_run[0])
 
         update_steps_to_run()
 

--- a/tango/integrations/wandb/step_cache.py
+++ b/tango/integrations/wandb/step_cache.py
@@ -11,7 +11,7 @@ from wandb.errors import Error as WandbError
 from tango.common.aliases import PathOrStr
 from tango.common.file_lock import FileLock
 from tango.common.params import Params
-from tango.common.util import tango_cache_dir
+from tango.common.util import make_safe_filename, tango_cache_dir
 from tango.step import Step
 from tango.step_cache import CacheMetadata, StepCache
 from tango.step_caches.local_step_cache import LocalStepCache
@@ -42,7 +42,12 @@ class WandbStepCache(LocalStepCache):
 
     def __init__(self, project: str, entity: str):
         check_environment()
-        super().__init__(tango_cache_dir() / "wandb_cache")
+        super().__init__(
+            tango_cache_dir()
+            / "wandb_cache"
+            / make_safe_filename(entity)
+            / make_safe_filename(project)
+        )
         self.project = project
         self.entity = entity
 


### PR DESCRIPTION
Fixes issue where remote `Workspace` implementations would always use the same local cache directory, regardless of the workspace's configuration.