### PR TITLE
`BeakerExecutor` improvements, fix bug with `StepIndexer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed issue where Executor `parallelism` option in a Tango settings file would be ignored.
+- Fixed a bug where the unique ID of a step that depends on a key-value of the result of another step could change if the name of the other step changes.
 
 ## [v1.0.2](https://github.com/allenai/tango/releases/tag/v1.0.2) - 2022-11-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Added `run_local` option to `BeakerExecutor` for making some steps run locally.
+
 ### Removed
 
 - Removed PyTorch Lightning integration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added `run_local` option to `BeakerExecutor` for making some steps run locally.
 - Added `gpu_type` field to `StepResources`. The `BeakerExecutor` can use this to determine which clusters to a submit a step to.
+- Added `machine` field to `StepResources`. You can set this to "local" when using the `BeakerExecutor` to force it to run the step locally.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added `run_local` option to `BeakerExecutor` for making some steps run locally.
+- Added `gpu_type` field to `StepResources`. The `BeakerExecutor` can use this to determine which clusters to a submit a step to.
 
 ### Removed
 

--- a/tango/__main__.py
+++ b/tango/__main__.py
@@ -797,7 +797,7 @@ def _run(
         run = workspace.register_run((step for step in step_graph.values()), name)
 
     def log_and_execute_run():
-        if step_name is None:
+        if not called_by_executor:
             cli_logger.info("[green]Starting new run [bold]%s[/][/]", run.name)
 
         # Initialize server.

--- a/tango/integrations/beaker/__init__.py
+++ b/tango/integrations/beaker/__init__.py
@@ -20,6 +20,7 @@ from .executor import (
     ResourceAssignment,
     ResourceAssignmentError,
     SimpleBeakerScheduler,
+    UnrecoverableResourceAssignmentError,
 )
 from .step_cache import BeakerStepCache
 from .workspace import BeakerWorkspace
@@ -32,4 +33,5 @@ __all__ = [
     "SimpleBeakerScheduler",
     "ResourceAssignment",
     "ResourceAssignmentError",
+    "UnrecoverableResourceAssignmentError",
 ]

--- a/tango/integrations/beaker/executor.py
+++ b/tango/integrations/beaker/executor.py
@@ -6,7 +6,6 @@ import time
 import uuid
 import warnings
 from abc import abstractmethod
-from fnmatch import fnmatch
 from typing import Dict, List, NamedTuple, Optional, Sequence, Set, Tuple, Union
 
 from beaker import (
@@ -247,8 +246,6 @@ class BeakerExecutor(Executor):
         ``clusters`` and ``priority``.
     :param allow_dirty: By default, the Beaker Executor requires that your git working directory has no uncommitted
         changes. If you set this to ``True``, we skip this check.
-    :param run_local: If you want some steps to run locally (as opposed to on Beaker), pass
-        those step names or glob patterns here.
     :param kwargs: Additional keyword arguments passed to :meth:`Beaker.from_env() <beaker.Beaker.from_env()>`.
 
     .. attention::
@@ -355,7 +352,6 @@ class BeakerExecutor(Executor):
         priority: Optional[Union[str, Priority]] = None,
         allow_dirty: bool = False,
         scheduler: Optional[BeakerScheduler] = None,
-        run_local: Optional[Set[str]] = None,
         **kwargs,
     ):
         # Pre-validate arguments.
@@ -405,7 +401,6 @@ class BeakerExecutor(Executor):
         self.venv_name = venv_name
         self.install_cmd = install_cmd
         self.allow_dirty = allow_dirty
-        self.run_local = run_local or set()
         self.scheduler: BeakerScheduler
         if scheduler is None:
             if clusters is None:
@@ -688,7 +683,7 @@ class BeakerExecutor(Executor):
             )
             return None
 
-        if any([fnmatch(step_name, pattern) for pattern in self.run_local]):
+        if step.resources.machine == "local":
             if step.cache_results:
                 step.ensure_result(self.workspace)
             else:

--- a/tango/integrations/beaker/executor.py
+++ b/tango/integrations/beaker/executor.py
@@ -6,6 +6,7 @@ import time
 import uuid
 import warnings
 from abc import abstractmethod
+from fnmatch import fnmatch
 from typing import Dict, List, NamedTuple, Optional, Sequence, Set, Tuple, Union
 
 from beaker import (
@@ -214,6 +215,8 @@ class BeakerExecutor(Executor):
         ``clusters`` and ``priority``.
     :param allow_dirty: By default, the Beaker Executor requires that your git working directory has no uncommitted
         changes. If you set this to ``True``, we skip this check.
+    :param run_local: If you want some steps to run locally (as opposed to on Beaker), pass
+        those step names or glob patterns here.
     :param kwargs: Additional keyword arguments passed to :meth:`Beaker.from_env() <beaker.Beaker.from_env()>`.
 
     .. attention::
@@ -320,6 +323,7 @@ class BeakerExecutor(Executor):
         priority: Optional[Union[str, Priority]] = None,
         allow_dirty: bool = False,
         scheduler: Optional[BeakerScheduler] = None,
+        run_local: Optional[Set[str]] = None,
         **kwargs,
     ):
         # Pre-validate arguments.
@@ -369,6 +373,7 @@ class BeakerExecutor(Executor):
         self.venv_name = venv_name
         self.install_cmd = install_cmd
         self.allow_dirty = allow_dirty
+        self.run_local = run_local or set()
         self.scheduler: BeakerScheduler
         if scheduler is None:
             if clusters is None:
@@ -649,6 +654,17 @@ class BeakerExecutor(Executor):
                 '[green]\N{check mark} Found output for step [bold]"%s"[/] in cache...[/]',
                 step_name,
             )
+            return None
+
+        if any([fnmatch(step_name, pattern) for pattern in self.run_local]):
+            if step.cache_results:
+                step.ensure_result(self.workspace)
+            else:
+                result = step.result(self.workspace)
+                if hasattr(result, "__next__"):
+                    from collections import deque
+
+                    deque(result, maxlen=0)
             return None
 
         experiment: Optional[Experiment] = None

--- a/tango/step.py
+++ b/tango/step.py
@@ -67,6 +67,14 @@ class StepResources(FromParams):
     step to run.
     """
 
+    machine: Optional[str] = None
+    """
+    This is an executor-dependent option.
+
+    With the Beaker executor, for example, you can set this to "local" to force
+    the executor to run the step locally instead of on Beaker.
+    """
+
     cpu_count: Optional[float] = None
     """
     Minimum number of logical CPU cores. It may be fractional.
@@ -81,7 +89,11 @@ class StepResources(FromParams):
 
     gpu_type: Optional[str] = None
     """
-    The type of GPU that the step requires, e.g. 'NVIDIA A100-SXM-80GB'.
+    The type of GPU that the step requires.
+
+    The exact string you should use to define a GPU type depends on the executor.
+    With the Beaker executor, for example, you should use the same strings you
+    see in the Beaker UI, such as 'NVIDIA A100-SXM-80GB'.
     """
 
     memory: Optional[str] = None

--- a/tango/step.py
+++ b/tango/step.py
@@ -722,7 +722,7 @@ class Step(Registrable, Generic[T]):
         cli_logger.error('[red]\N{ballot x} Step [bold]"%s"[/] failed[/]', self.name)
 
 
-class StepIndexer:
+class StepIndexer(CustomDetHash):
     def __init__(self, step: Step, key: Union[str, int]):
         self.step = step
         self.key = key
@@ -731,6 +731,9 @@ class StepIndexer:
         self, workspace: Optional["Workspace"] = None, needed_by: Optional["Step"] = None
     ) -> Any:
         return self.step.result(workspace=workspace, needed_by=needed_by)[self.key]
+
+    def det_hash_object(self) -> Any:
+        return self.step.unique_id, self.key
 
 
 class WithUnresolvedSteps(CustomDetHash):

--- a/tango/step.py
+++ b/tango/step.py
@@ -79,6 +79,11 @@ class StepResources(FromParams):
     Minimum number of GPUs. It must be non-negative.
     """
 
+    gpu_type: Optional[str] = None
+    """
+    The type of GPU that the step requires, e.g. 'NVIDIA A100-SXM-80GB'.
+    """
+
     memory: Optional[str] = None
     """
     Minimum available system memory as a number with unit suffix.


### PR DESCRIPTION
Changes proposed:
- Adds field `run_local` to `BeakerExecutor`. You can use this to have the executor run certain steps locally. For instance, if you have a bunch of catwalk "tabulate-metrics" steps that are called "*-metrics" in your config, you could put `run_local: ["*-metrics"]` in your settings YAML file.
- Adds a field `gpu_type` to `StepResources`, and the `BeakerExecutor` will use this to find clusters with a matching GPU type.
- Fixes the unique ID for `StepIndexer`.