### PR TITLE
reset sys.excepthook after importing other modules, add `--ext-var` CLI option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `gpu_type` field to `StepResources`. The `BeakerExecutor` can use this to determine which clusters to a submit a step to.
 - Added `machine` field to `StepResources`. You can set this to "local" when using the `BeakerExecutor` to force it to run the step locally.
+- Added `--ext-var` argument to `tango run` for setting JSONNET external variables
+  when loading the experiment config.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed issue where Executor `parallelism` option in a Tango settings file would be ignored.
 - Fixed a bug where the unique ID of a step that depends on a key-value of the result of another step could change if the name of the other step changes.
+- Fixed a bug where importing certain libraries (like torchmetrics) would mess with our exception handling because they set `sys.excepthook` for some reason. Now we always reset `sys.excepthook` after importing.
 
 ## [v1.0.2](https://github.com/allenai/tango/releases/tag/v1.0.2) - 2022-11-14
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ retry                        # needed by: wandb
 transformers>=4.12.3         # needed by: transformers
 sentencepiece==0.1.97        # needed by: transformers
 fairscale>=0.4.6,<0.5        # needed by: fairscale
-beaker-py>=1.11.4,<2.0       # needed by: beaker
+beaker-py>=1.11.6,<2.0       # needed by: beaker
 
 # sacremoses should be a dependency of transformers, but it is missing, so we add it manually.
 sacremoses                   # needed by: transformers

--- a/tango/__main__.py
+++ b/tango/__main__.py
@@ -286,7 +286,7 @@ def cleanup(*args, **kwargs):
     help="""Specify the name for this run.""",
 )
 @click.option(
-    "-e",
+    "-D",
     "--ext-var",
     type=str,
     help="""JSONNET external variables to use when loading the experiment config.

--- a/tango/__main__.py
+++ b/tango/__main__.py
@@ -80,7 +80,7 @@ import os
 import sys
 import warnings
 from pathlib import Path
-from typing import TYPE_CHECKING, List, Optional, Sequence, Union
+from typing import TYPE_CHECKING, Dict, List, Optional, Sequence, Union
 
 import click
 from click_help_colors import HelpColorsCommand, HelpColorsGroup
@@ -285,6 +285,14 @@ def cleanup(*args, **kwargs):
     type=str,
     help="""Specify the name for this run.""",
 )
+@click.option(
+    "-e",
+    "--ext-var",
+    type=str,
+    help="""JSONNET external variables to use when loading the experiment config.
+    For example, --ext-var 'pretrained_model=gpt2'.""",
+    multiple=True,
+)
 @click.pass_obj
 def run(
     settings: TangoGlobalSettings,
@@ -297,6 +305,7 @@ def run(
     parallelism: Optional[int] = None,
     step_name: Optional[str] = None,
     name: Optional[str] = None,
+    ext_var: Optional[Sequence[str]] = None,
 ):
     """
     Run a tango experiment.
@@ -329,6 +338,7 @@ def run(
         step_name=step_name,
         name=name,
         called_by_executor=_CALLED_BY_EXECUTOR,
+        ext_var=ext_var,
     )
 
 
@@ -707,6 +717,7 @@ def _run(
     multicore: Optional[bool] = None,
     name: Optional[str] = None,
     called_by_executor: bool = False,
+    ext_var: Optional[Sequence[str]] = None,
 ) -> str:
     from tango.executor import Executor
     from tango.executors import MulticoreExecutor
@@ -714,7 +725,14 @@ def _run(
     from tango.workspaces import MemoryWorkspace, default_workspace
 
     # Read params.
-    params = Params.from_file(experiment, params_overrides=overrides or "")
+    ext_vars: Dict[str, str] = {}
+    for var in ext_var or []:
+        try:
+            key, value = var.split("=")
+        except ValueError:
+            raise CliRunError(f"Invalid --ext-var '{var}'")
+        ext_vars[key] = value
+    params = Params.from_file(experiment, params_overrides=overrides or "", ext_vars=ext_vars)
 
     # Import included packages to find registered components.
     # NOTE: The Executor imports these as well because it's meant to be used

--- a/tango/common/util.py
+++ b/tango/common/util.py
@@ -102,8 +102,16 @@ def import_module_and_submodules(
     else:
         sys.path.insert(0, sys.path.pop(sys.path.index(str(base_path))))
 
+    # Certain packages might mess with sys.excepthook, which we don't want since
+    # we mess with sys.excepthook ourselves, so we reset it after importing.
+    excepthook = sys.excepthook
+
     # Import at top level
-    module = importlib.import_module(package_name)
+    try:
+        module = importlib.import_module(package_name)
+    finally:
+        sys.excepthook = excepthook
+
     path = getattr(module, "__path__", [])
     path_string = "" if not path else path[0]
 


### PR DESCRIPTION
Changes:
- [feature] adds a command line option to `tango run`: `--ext-var`. Use this to set JSONNET external variables when loading the experiment configuration file. For example, `--ext-var 'pretrained_model=gpt2'`.
- [bug fix]I was confused why our exception handling wasn't working as expected for me all of the sudden. After digging into it, I realized that `torchmetrics` (or some dependency of `torchmetrics`) is messing with `sys.excepthook`. But Tango should be only one messing with `sys.excepthook`.