### PR TITLE
Add `@step()` decorator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `machine` field to `StepResources`. You can set this to "local" when using the `BeakerExecutor` to force it to run the step locally.
 - Added `--ext-var` argument to `tango run` for setting JSONNET external variables
   when loading the experiment config.
+- Added `@step()` decorator to create `Step` classes from functions.
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,19 @@ AI2 Tango replaces messy directories and spreadsheets full of file versions by o
 - [Contributing](https://github.com/allenai/tango/blob/main/CONTRIBUTING.md)
 - [License](https://github.com/allenai/tango/blob/main/LICENSE)
 
+## In this README
+
+- [Quick start](#quick-start)
+- [Installation](#installation)
+  - [Installing with PIP](#installing-with-pip)
+  - [Installing with Conda](#installing-with-conda)
+  - [Installing from source](#installing-from-source)
+  - [Checking your installation](#checking-your-installation)
+  - [Docker image](#docker-image)
+- [FAQ](#faq)
+- [Team](#team)
+- [License](#license)
+
 ## Quick start
 
 Create a Tango step:

--- a/README.md
+++ b/README.md
@@ -31,6 +31,65 @@ AI2 Tango replaces messy directories and spreadsheets full of file versions by o
 - [Contributing](https://github.com/allenai/tango/blob/main/CONTRIBUTING.md)
 - [License](https://github.com/allenai/tango/blob/main/LICENSE)
 
+## Quick start
+
+Create a Tango step:
+
+```python
+# hello.py
+
+from tango import step
+
+@step()
+def hello(name: str) -> str:
+    message = f"Hello, {name}!"
+    print(message)
+    return message
+```
+
+And create a corresponding experiment configuration file:
+
+```jsonnet
+// hello.jsonnet
+
+{
+  steps: {
+    hello: {
+      type: "hello",
+      name: "World",
+    }
+  }
+}
+```
+
+Then run the experiment using a local workspace to cache the result:
+
+```bash
+tango run hello.jsonnet -w /tmp/workspace
+```
+
+You'll see something like this in the output:
+
+```
+Starting new run expert-llama
+● Starting step "hello"...
+Hello, World!
+✓ Finished step "hello"
+✓ Finished run expert-llama
+```
+
+If you run this a second time the output will now look like this:
+
+```
+Starting new run open-crab
+✓ Found output for step "hello" in cache...
+✓ Finished run open-crab
+```
+
+You won't see "Hello, World!" this time because the result of the step was found in the cache, so it wasn't run again.
+
+For a more detailed introduction check out the [First Steps](https://ai2-tango.readthedocs.io/en/latest/first_steps.html) walk-through.
+
 ## Installation
 
 <!-- start install -->

--- a/docs/source/api/components/step.rst
+++ b/docs/source/api/components/step.rst
@@ -9,6 +9,8 @@ Base class
    :special-members:
    :exclude-members: from_params
 
+.. autofunction:: tango.step.step
+
 .. autoclass:: tango.step.WithUnresolvedSteps
    :members:
 

--- a/docs/source/first_steps.md
+++ b/docs/source/first_steps.md
@@ -120,6 +120,28 @@ and warn you when the types don't match up.
 So as long as Tango is able to import this module (`components.py`) these step implementations will be added to the registry
 and Tango will know how to instantiate and run them.
 
+There's also a short-hand way of implementing steps, using the {func}`@step() <tango.step.step>` function decorator:
+
+```python
+from tango import step
+
+@step(deterministic=False)
+def random_choice(choices: List[str]) -> str:
+    return random.choice(choices)
+
+@step()
+def concat_strings(string1: str, string2: str) -> str:
+    return string1 + string2
+```
+
+This will register these steps under the name of the corresponding function, i.e. "random_choice" and "concat_strings", by default, though that can be overridden by specifying the "name" parameter to the decorator:
+
+```python
+@step(name="random-string", deterministic=False)
+def random_choice(choices: List[str]) -> str:
+    return random.choice(choices)
+```
+
 ## Executing an experiment
 
 At this point we've implemented our custom steps (`components.py`) and created our configuration

--- a/tango/__init__.py
+++ b/tango/__init__.py
@@ -11,8 +11,10 @@ __all__ = [
     "JsonFormatIterator",
     "SqliteDictFormat",
     "Step",
+    "step",
     "StepResources",
     "StepCache",
+    "StepGraph",
     "Workspace",
 ]
 
@@ -25,7 +27,7 @@ from tango.format import (
     JsonFormatIterator,
     SqliteDictFormat,
 )
-from tango.step import Step, StepResources
+from tango.step import Step, StepResources, step
 from tango.step_cache import StepCache
 from tango.step_graph import StepGraph
 from tango.workspace import Workspace

--- a/tango/common/from_params.py
+++ b/tango/common/from_params.py
@@ -387,7 +387,7 @@ def construct_arg(
     if popped_params is default:
         return popped_params
 
-    from tango.step import Step, StepIndexer, WithUnresolvedSteps
+    from tango.step import FunctionalStep, Step, StepIndexer, WithUnresolvedSteps
 
     origin = getattr(annotation, "__origin__", None)
     args = getattr(annotation, "__args__", [])
@@ -457,7 +457,10 @@ def construct_arg(
 
             if isinstance(result, Step):
                 expected_return_type = args[0]
-                return_type = inspect.signature(result.run).return_annotation
+                if isinstance(result, FunctionalStep):
+                    return_type = inspect.signature(result.WRAPPED_FUNC).return_annotation
+                else:
+                    return_type = inspect.signature(result.run).return_annotation
                 if return_type == inspect.Signature.empty:
                     logger.warning(
                         "Step %s has no return type annotation. Those are really helpful when "


### PR DESCRIPTION
Adds a decorator for creating steps from functions:

```python
from tango import step

@step(version="001")
def add(a: int, b: int) -> int:
    return a + b
```