### PR TITLE
Fix #483

### DIFF
--- a/tango/common/params.py
+++ b/tango/common/params.py
@@ -191,7 +191,7 @@ def pop_choice(
 
 
 def _replace_none(params: Any) -> Any:
-    if params == "None":
+    if isinstance(params, str) and params == "None":
         return None
     elif isinstance(params, (dict, Params)):
         if isinstance(params, Params):


### PR DESCRIPTION
<!-- To ensure we can review your pull request promptly please complete this template entirely. -->

<!-- Please reference the issue number here. You can replace "Fixes" with "Closes" if it makes more sense. -->
Fixes #483

I don't even know why we call this `_replace_none()` function. Looking at the blame history I think it's just a legacy thing from allennlp, so it would probably be fine to remove it. But to make this bug fix less intrusive I'll leave it in for now.