### PR TITLE
Fix integration status messages in `tango info` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - You can now add arguments to steps without invalidating the cache. See `Step.SKIP_DEFAULT_ARGUMENTS`.
+- Fixed integration status messages in `tango info` command.
 
 
 ## [v1.1.0](https://github.com/allenai/tango/releases/tag/v1.1.0) - 2022-12-01

--- a/tango/__main__.py
+++ b/tango/__main__.py
@@ -421,7 +421,7 @@ def info(settings: TangoGlobalSettings):
         name = integration.split(".")[-1]
         is_installed = True
         try:
-            import_module_and_submodules(integration)
+            import_module_and_submodules(integration, recursive=False)
         except (IntegrationMissingError, ModuleNotFoundError, ImportError):
             is_installed = False
         if is_installed:


### PR DESCRIPTION
We shouldn't be trying to import every file in an integration's submodule to check if the integration is active, only the top-level submodule.