### PR TITLE
Add `bind` option to `@step` decorator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - You can now add arguments to steps without invalidating the cache. See `Step.SKIP_DEFAULT_ARGUMENTS`.
 - Fixed integration status messages in `tango info` command.
+- You can now bind functional steps to the underlying `Step` instance with `@step(bind=True)`, meaning the first argument to the function will be a `Step`.
 
 ### Fixed
 

--- a/tango/step.py
+++ b/tango/step.py
@@ -381,6 +381,13 @@ class Step(Registrable, Generic[T]):
 
         if issubclass(subclass, FunctionalStep):
             parameters = infer_method_params(subclass, subclass.WRAPPED_FUNC, infer_kwargs=False)
+            if subclass.BIND:
+                if "self" not in parameters:
+                    raise ConfigurationError(
+                        f"Functional step for {subclass.WRAPPED_FUNC} is bound but is missing argument 'self'"
+                    )
+                else:
+                    del parameters["self"]
         else:
             parameters = infer_method_params(subclass, subclass.run, infer_kwargs=False)
             del parameters["self"]
@@ -761,19 +768,24 @@ class Step(Registrable, Generic[T]):
 
 class FunctionalStep(Step):
     WRAPPED_FUNC: ClassVar[Callable]
+    BIND: ClassVar[bool] = False
 
     @property
     def class_name(self) -> str:
         return self.WRAPPED_FUNC.__name__
 
     def run(self, *args, **kwargs):
-        return self.__class__.WRAPPED_FUNC(*args, **kwargs)
+        if self.BIND:
+            return self.WRAPPED_FUNC(*args, **kwargs)
+        else:
+            return self.__class__.WRAPPED_FUNC(*args, **kwargs)
 
 
 def step(
     name: Optional[str] = None,
     *,
     exist_ok: bool = False,
+    bind: bool = False,
     deterministic: bool = True,
     cacheable: Optional[bool] = None,
     version: Optional[str] = None,
@@ -788,6 +800,10 @@ def step(
     :param exist_ok:
         If True, overwrites any existing step registered under the same ``name``. Else,
         throws an error if a step is already registered under ``name``.
+    :param bind: If ``True``, the first argument passed to the step function will
+        be the underlying :class:`Step` instance, i.e. the function will be called as an instance method.
+        In this case you must name the first argument 'self' or you will get a
+        :class:`~tango.common.exceptions.ConfigurationError` when instantiating the class.
 
     See the :class:`Step` class for an explanation of the other parameters.
 
@@ -801,6 +817,10 @@ def step(
         @step(version="001")
         def add(a: int, b: int) -> int:
             return a + b
+
+        @step(bind=True)
+        def bound_step(self) -> None:
+            assert self.work_dir.is_dir()
     """
 
     def step_wrapper(step_func):
@@ -814,6 +834,7 @@ def step(
             METADATA = metadata or {}
 
             WRAPPED_FUNC = step_func
+            BIND = bind
 
         return WrapperStep
 


### PR DESCRIPTION
Setting `bind=True` means the first argument will always be a `Step` instance, and must be called "self".

This is analogous to how you can create bound tasks in Celery. https://docs.celeryq.dev/en/stable/userguide/tasks.html#bound-tasks

For example:

```python
from tango import step


@step(bind=True, exist_ok=True)
def bound_step(self, x: int) -> None:
    print(x)
    assert self.work_dir.is_dir()


bound_step(x=2).result()
```