### PR TITLE
Allow specifying multiple steps with `-s` from `tango run`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - The default log level for Tango is now `warning`.
+- You can specify multiple steps with `-s` from the `tango run` command.
 
 
 ## [v1.1.0](https://github.com/allenai/tango/releases/tag/v1.1.0) - 2022-12-01

--- a/tango/__main__.py
+++ b/tango/__main__.py
@@ -775,7 +775,7 @@ def _run(
                 raise CliRunError
 
     if called_by_executor:
-        assert step_names
+        assert step_names is not None and len(step_names) == 1
 
         from tango.common.aliases import EnvVarNames
 

--- a/tango/__main__.py
+++ b/tango/__main__.py
@@ -263,8 +263,6 @@ def cleanup(*args, **kwargs):
     "-s",
     "--step-name",
     help="Execute a particular step (and its dependencies) in the experiment.",
-    type=str,
-    default=None,
     multiple=True,
 )
 @click.option(
@@ -752,15 +750,16 @@ def _run(
             cli_logger.info("[green]Starting new run [bold]%s[/][/]", run.name)
 
         executor_output: Optional[ExecutorOutput] = None
-        if step_name is not None:
+        if step_names:
             assert sub_graph is not None
-            step = sub_graph[step_name]
-            if step.cache_results and step in workspace.step_cache:
-                step.log_cache_hit()
-            else:
-                executor_output = executor.execute_sub_graph_for_step(
-                    sub_graph, step_name, run_name=run.name
-                )
+            for step_name in step_names:
+                step = sub_graph[step_name]
+                if step.cache_results and step in workspace.step_cache:
+                    step.log_cache_hit()
+                else:
+                    executor_output = executor.execute_sub_graph_for_step(
+                        sub_graph, step_name, run_name=run.name
+                    )
         else:
             executor_output = executor.execute_step_graph(step_graph, run_name=run.name)
 

--- a/tango/__main__.py
+++ b/tango/__main__.py
@@ -752,14 +752,9 @@ def _run(
         executor_output: Optional[ExecutorOutput] = None
         if step_names:
             assert sub_graph is not None
-            for step_name in step_names:
-                step = sub_graph[step_name]
-                if step.cache_results and step in workspace.step_cache:
-                    step.log_cache_hit()
-                else:
-                    executor_output = executor.execute_sub_graph_for_step(
-                        sub_graph, step_name, run_name=run.name
-                    )
+            executor_output = executor.execute_sub_graph_for_steps(
+                sub_graph, *step_names, run_name=run.name
+            )
         else:
             executor_output = executor.execute_step_graph(step_graph, run_name=run.name)
 

--- a/tango/__main__.py
+++ b/tango/__main__.py
@@ -265,6 +265,7 @@ def cleanup(*args, **kwargs):
     help="Execute a particular step (and its dependencies) in the experiment.",
     type=str,
     default=None,
+    multiple=True,
 )
 @click.option(
     "-n",
@@ -289,7 +290,7 @@ def run(
     overrides: Optional[str] = None,
     include_package: Optional[Sequence[str]] = None,
     parallelism: Optional[int] = None,
-    step_name: Optional[str] = None,
+    step_name: Optional[Sequence[str]] = None,
     name: Optional[str] = None,
     ext_var: Optional[Sequence[str]] = None,
 ):
@@ -320,7 +321,7 @@ def run(
         overrides=overrides,
         include_package=include_package,
         parallelism=parallelism,
-        step_name=step_name,
+        step_names=step_name,
         name=name,
         called_by_executor=_CALLED_BY_EXECUTOR,
         ext_var=ext_var,
@@ -644,7 +645,7 @@ def _run(
     workspace_url: Optional[str] = None,
     overrides: Optional[str] = None,
     include_package: Optional[Sequence[str]] = None,
-    step_name: Optional[str] = None,
+    step_names: Optional[Sequence[str]] = None,
     parallelism: Optional[int] = None,
     multicore: Optional[bool] = None,
     name: Optional[str] = None,
@@ -726,12 +727,13 @@ def _run(
 
     # Register run.
     run: "Run"
-    if step_name is not None:
-        assert step_name in step_graph, (
-            f"You want to run a step called '{step_name}', but it cannot be found in the experiment config. "
-            f"The config contains: {list(step_graph.keys())}."
-        )
-        sub_graph = step_graph.sub_graph(step_name)
+    if step_names:
+        for step_name in step_names:
+            assert step_name in step_graph, (
+                f"You want to run a step called '{step_name}', but it cannot be found in the experiment config. "
+                f"The config contains: {list(step_graph.keys())}."
+            )
+        sub_graph = step_graph.sub_graph(*step_names)
         if called_by_executor and name is not None:
             try:
                 run = workspace.registered_run(name)
@@ -774,12 +776,14 @@ def _run(
                 raise CliRunError
 
     if called_by_executor:
+        assert step_names
+
         from tango.common.aliases import EnvVarNames
 
         # We set this environment variable so that any steps that contain multiprocessing
         # and call `initialize_worker_logging` also log the messages with the `step_name` prefix.
-        os.environ[EnvVarNames.LOGGING_PREFIX.value] = f"step {step_name}"
-        initialize_prefix_logging(prefix=f"step {step_name}", main_process=False)
+        os.environ[EnvVarNames.LOGGING_PREFIX.value] = f"step {step_names[0]}"
+        initialize_prefix_logging(prefix=f"step {step_names[0]}", main_process=False)
         log_and_execute_run()
     else:
         # Capture logs to file.

--- a/tango/common/testing/__init__.py
+++ b/tango/common/testing/__init__.py
@@ -108,7 +108,7 @@ class TangoTestCase:
             workspace_url=workspace_url or "local://" + str(self.TEST_DIR / "workspace"),
             overrides=overrides,
             include_package=include_package,
-            step_name=step_name,
+            step_names=None if not step_name else [step_name],
             parallelism=parallelism,
             multicore=multicore,
             name=name,

--- a/tango/executor.py
+++ b/tango/executor.py
@@ -127,14 +127,14 @@ class Executor(Registrable):
     # serialize steps somehow, and the easiest way to serialize a step is by serializing the
     # whole step config (which can be accessed via the step graph).
 
-    def execute_sub_graph_for_step(
-        self, step_graph: StepGraph, step_name: str, run_name: Optional[str] = None
+    def execute_sub_graph_for_steps(
+        self, step_graph: StepGraph, *step_names: str, run_name: Optional[str] = None
     ) -> ExecutorOutput:
         """
         Execute the sub-graph associated with a particular step in a
         :class:`~tango.step_graph.StepGraph`.
         """
-        sub_graph = step_graph.sub_graph(step_name)
+        sub_graph = step_graph.sub_graph(*step_names)
         return self.execute_step_graph(sub_graph, run_name=run_name)
 
 

--- a/tango/step_graph.py
+++ b/tango/step_graph.py
@@ -127,14 +127,18 @@ class StepGraph(Mapping[str, Step]):
 
         return cls(step_dict)
 
-    def sub_graph(self, step_name: str) -> "StepGraph":
-        if step_name not in self.parsed_steps:
-            raise KeyError(
-                f"{step_name} is not a part of this StepGraph. "
-                f"Available steps are: {list(self.parsed_steps.keys())}"
+    def sub_graph(self, *step_names: str) -> "StepGraph":
+        step_dict: Dict[str, Step] = {}
+        for step_name in step_names:
+            if step_name not in self.parsed_steps:
+                raise KeyError(
+                    f"{step_name} is not a part of this StepGraph. "
+                    f"Available steps are: {list(self.parsed_steps.keys())}"
+                )
+            step_dict.update(
+                {dep.name: dep for dep in self.parsed_steps[step_name].recursive_dependencies}
             )
-        step_dict = {dep.name: dep for dep in self.parsed_steps[step_name].recursive_dependencies}
-        step_dict[step_name] = self.parsed_steps[step_name]
+            step_dict[step_name] = self.parsed_steps[step_name]
         return StepGraph(step_dict)
 
     @staticmethod


### PR DESCRIPTION
For example, `tango run config.jsonnet -s foo -s bar`.