### PR TITLE
minor workspace fixes

### DIFF
--- a/tango/common/from_params.py
+++ b/tango/common/from_params.py
@@ -345,7 +345,11 @@ def pop_and_construct_arg(
                 "get unexpected behavior."
             )
 
-    popped_params = params.pop(name, default) if default != _NO_DEFAULT else params.pop(name)
+    try:
+        popped_params = params.pop(name, default) if default != _NO_DEFAULT else params.pop(name)
+    except ConfigurationError:
+        raise ConfigurationError(f"Missing key '{name}' for {class_name}")
+
     if popped_params is None:
         return None
 

--- a/tango/common/from_params.py
+++ b/tango/common/from_params.py
@@ -348,7 +348,7 @@ def pop_and_construct_arg(
     try:
         popped_params = params.pop(name, default) if default != _NO_DEFAULT else params.pop(name)
     except ConfigurationError:
-        raise ConfigurationError(f"Missing key '{name}' for {class_name}")
+        raise ConfigurationError(f'Missing key "{name}" for {class_name}')
 
     if popped_params is None:
         return None

--- a/tango/integrations/beaker/workspace.py
+++ b/tango/integrations/beaker/workspace.py
@@ -162,7 +162,7 @@ class BeakerWorkspace(RemoteWorkspace):
             if cached is not None:
                 step_info = cached
             else:
-                step_info_bytes = self.beaker.dataset.get_file(dataset, file_info)
+                step_info_bytes = self.beaker.dataset.get_file(dataset, file_info, quiet=True)
                 step_info = StepInfo.from_json_dict(json.loads(step_info_bytes))
                 if file_info.digest is not None:
                     self._add_object_to_cache(file_info.digest, step_info)
@@ -249,7 +249,7 @@ class BeakerWorkspace(RemoteWorkspace):
 
     def _save_run_log(self, name: str, log_file: Path):
         run_dataset = self.Constants.run_artifact_name(name)
-        self.beaker.dataset.sync(run_dataset, log_file, quiet=False)
+        self.beaker.dataset.sync(run_dataset, log_file, quiet=True)
         self.beaker.dataset.commit(run_dataset)
 
     def _get_run_from_dataset(self, dataset: BeakerDataset) -> Optional[Run]:

--- a/tango/workspace.py
+++ b/tango/workspace.py
@@ -301,4 +301,4 @@ class Workspace(Registrable):
         return do_nothing()
 
 
-Workspace.register("from_url", constructor="from_url")
+Workspace.register("from_url", constructor="from_url")(Workspace)

--- a/tango/workspace.py
+++ b/tango/workspace.py
@@ -301,4 +301,4 @@ class Workspace(Registrable):
         return do_nothing()
 
 
-Workspace.register("from_url", constructor="from_url")(Workspace)
+Workspace.register("from_url", constructor="from_url")(Workspace)  # type: ignore

--- a/tests/common/from_params_test.py
+++ b/tests/common/from_params_test.py
@@ -559,7 +559,7 @@ class TestFromParams(TangoTestCase):
         assert test3.lazy3.a == 3
         assert test3.lazy4 is None
 
-        with pytest.raises(ConfigurationError, match='key "lazy1" is required'):
+        with pytest.raises(ConfigurationError, match='Missing key "lazy1" for Testing'):
             Testing.from_params(Params({}))
 
     def test_wrapper_kwargs_passed_down(self):


### PR DESCRIPTION
All uploads/downloads to Beaker are quiet now. Makes the `Workspace.from_url()` actually registered.