### PR TITLE
Fix bug with variable length tuples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Warnings about locks are now reliably printed every 30 seconds
 - We now make sure Beaker jobs have the latest version of beaker-py, so that we're compatible with the latest API changes.
 - Stopping early now works when the metric doesn't change at all.
+- Fixed bug with `FromParams` which didn't handle variable length tuples correctly.
 
 ### Changed
 

--- a/tango/common/from_params.py
+++ b/tango/common/from_params.py
@@ -559,7 +559,14 @@ def construct_arg(
     elif origin in (Tuple, tuple):
         value_list = []
 
-        for i, (value_cls, value_params) in enumerate(zip(annotation.__args__, popped_params)):
+        value_types = list(annotation.__args__)
+        if value_types[-1] == Ellipsis:
+            # Variable length tuples, e.g. 'Tuple[int, ...]', we set value_types to '[int] * len(popped_params)'.
+            value_types = value_types[:-1] + [value_types[-2]] * (
+                len(popped_params) - len(annotation.__args__) + 1
+            )
+
+        for i, (value_cls, value_params) in enumerate(zip(value_types, popped_params)):
             value = construct_arg(
                 str(value_cls),
                 argument_name + f".{i}",

--- a/tests/common/from_params_test.py
+++ b/tests/common/from_params_test.py
@@ -141,6 +141,13 @@ class TestFromParams(TangoTestCase):
         assert c.name == "extra_c"  # type: ignore[attr-defined]
         assert c.size == 20  # type: ignore[attr-defined]
 
+    def test_variable_length_tuple(self):
+        class Foo(FromParams):
+            def __init__(self, x: Tuple[Optional[int], ...]):
+                self.x = x
+
+        assert Foo.from_params({"x": [None, 1, 2]}).x == (None, 1, 2)
+
     def test_union(self):
         class A(FromParams):
             def __init__(self, a: Union[int, List[int]]) -> None:

--- a/tests/common/from_params_test.py
+++ b/tests/common/from_params_test.py
@@ -146,7 +146,9 @@ class TestFromParams(TangoTestCase):
             def __init__(self, x: Tuple[Optional[int], ...]):
                 self.x = x
 
-        assert Foo.from_params({"x": [None, 1, 2]}).x == (None, 1, 2)
+        assert Foo.from_params({"x": [None, 1, 2, 3]}).x == (None, 1, 2, 3)
+        assert Foo.from_params({"x": [1, 2]}).x == (1, 2)
+        assert Foo.from_params({"x": [1]}).x == (1,)
 
     def test_union(self):
         class A(FromParams):


### PR DESCRIPTION
Annotations like `Tuple[int, ...]` were not handled correctly in `FromParams`. You'd always get at most two elements, e.g. `[1, 2, 3, 4]` would be parsed into `[1, 2]`.