### PR TITLE
Return more info from `Workspace.search_registered_runs()`

### DIFF
--- a/docs/source/api/components/workspace.rst
+++ b/docs/source/api/components/workspace.rst
@@ -19,3 +19,15 @@ Metadata
 
 .. autoclass:: tango.workspace.Run
    :members:
+
+.. autoclass:: tango.workspace.RunInfo
+   :members:
+
+Miscellaneous
+-------------
+
+.. autoclass:: tango.workspace.RunSort
+   :members:
+
+.. autoclass:: tango.workspace.StepInfoSort
+   :members:

--- a/tango/__init__.py
+++ b/tango/__init__.py
@@ -18,6 +18,8 @@ __all__ = [
     "StepResources",
     "StepCache",
     "StepGraph",
+    "Run",
+    "RunInfo",
     "RunSort",
     "Workspace",
 ]
@@ -35,4 +37,4 @@ from .step import Step, StepResources, step
 from .step_cache import StepCache
 from .step_graph import StepGraph
 from .step_info import StepInfo, StepState
-from .workspace import RunSort, StepInfoSort, Workspace
+from .workspace import Run, RunInfo, RunSort, StepInfoSort, Workspace

--- a/tango/integrations/beaker/workspace.py
+++ b/tango/integrations/beaker/workspace.py
@@ -22,7 +22,7 @@ from beaker import (
 from tango.common.util import make_safe_filename, tango_cache_dir
 from tango.step import Step
 from tango.step_info import StepInfo, StepState
-from tango.workspace import Run, RunSort, StepInfoSort, Workspace
+from tango.workspace import Run, RunInfo, RunSort, StepInfoSort, Workspace
 from tango.workspaces.remote_workspace import RemoteWorkspace
 
 from .common import BeakerStepLock, Constants, dataset_url, get_client
@@ -239,7 +239,7 @@ class BeakerWorkspace(RemoteWorkspace):
         match: Optional[str] = None,
         start: Optional[int] = None,
         stop: Optional[int] = None,
-    ) -> List[str]:
+    ) -> List[RunInfo]:
         if match is None:
             match = Constants.RUN_ARTIFACT_PREFIX
         else:
@@ -265,7 +265,7 @@ class BeakerWorkspace(RemoteWorkspace):
                 self.Constants.RUN_ARTIFACT_PREFIX
             ):
                 run_name = dataset.name[len(self.Constants.RUN_ARTIFACT_PREFIX) :]
-                runs.append(run_name)
+                runs.append(RunInfo(name=run_name, start_date=dataset.created))
 
         return runs
 

--- a/tango/integrations/gs/workspace.py
+++ b/tango/integrations/gs/workspace.py
@@ -18,7 +18,7 @@ from tango.integrations.gs.common import (
 from tango.integrations.gs.step_cache import GSStepCache
 from tango.step import Step
 from tango.step_info import StepInfo, StepState
-from tango.workspace import Run, RunSort, StepInfoSort, Workspace
+from tango.workspace import Run, RunInfo, RunSort, StepInfoSort, Workspace
 from tango.workspaces.remote_workspace import RemoteWorkspace
 
 T = TypeVar("T")
@@ -181,11 +181,14 @@ class GSWorkspace(RemoteWorkspace):
         match: Optional[str] = None,
         start: int = 0,
         stop: Optional[int] = None,
-    ) -> List[str]:
+    ) -> List[RunInfo]:
         run_entities = self._fetch_run_entities(
             sort_by=sort_by, sort_descending=sort_descending, match=match, start=start, stop=stop
         )
-        return [e.key.name for e in run_entities]
+        return [
+            RunInfo(name=e.key.name, start_date=e["start_date"], steps=json.loads(e["steps"]))
+            for e in run_entities
+        ]
 
     def num_registered_runs(self, *, match: Optional[str] = None) -> int:
         count = 0


### PR DESCRIPTION
@jonborchardt requested that we return as much info
as possible from this method. It makes the API a little
messy, but I think that's okay since these methods are
only designed for the UI.
