### PR TITLE
Only one step object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixes a bug where `FromParams` would fail to parse when an object takes a `Step` argument directly.
+- Changed a name so we don't override the built-in name `set`.
+
 
 ## [v1.2.0](https://github.com/allenai/tango/releases/tag/v1.2.0) - 2023-02-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixes a bug where `FromParams` would fail to parse when an object takes a `Step` argument directly.
 - Changed a name so we don't override the built-in name `set`.
+- Fixed a bug that would cause O(n^2) memory consumption in dense step graphs.
 
 
 ## [v1.2.0](https://github.com/allenai/tango/releases/tag/v1.2.0) - 2023-02-10

--- a/tango/__main__.py
+++ b/tango/__main__.py
@@ -467,7 +467,7 @@ def init(settings: TangoGlobalSettings, path: Optional[str] = None, force: bool 
 
 @settings.group(**_CLICK_GROUP_DEFAULTS)
 @click.pass_obj
-def set(settings: TangoGlobalSettings):
+def set_setting(settings: TangoGlobalSettings):
     """
     Set a value in the settings file.
     """
@@ -477,12 +477,12 @@ def set(settings: TangoGlobalSettings):
         )
 
 
-@set.result_callback()
+@set_setting.result_callback()
 def save_settings(settings: TangoGlobalSettings):
     settings.save()
 
 
-@set.command(**_CLICK_COMMAND_DEFAULTS)
+@set_setting.command(**_CLICK_COMMAND_DEFAULTS)
 @click.argument(
     "workspace",
     type=str,
@@ -516,7 +516,7 @@ def workspace(
     return settings
 
 
-@set.command(**_CLICK_COMMAND_DEFAULTS)
+@set_setting.command(**_CLICK_COMMAND_DEFAULTS)
 @click.argument(
     "packages",
     type=str,
@@ -562,7 +562,7 @@ def include_package(
     return settings
 
 
-@set.command(**_CLICK_COMMAND_DEFAULTS)
+@set_setting.command(**_CLICK_COMMAND_DEFAULTS)
 @click.argument(
     "level",
     type=click.Choice(["debug", "info", "warning", "error"], case_sensitive=False),
@@ -576,7 +576,7 @@ def log_level(settings: TangoGlobalSettings, level: str) -> TangoGlobalSettings:
     return settings
 
 
-@set.command(**_CLICK_COMMAND_DEFAULTS)
+@set_setting.command(**_CLICK_COMMAND_DEFAULTS)
 @click.argument(
     "value",
     type=bool,
@@ -590,7 +590,7 @@ def file_friendly_logging(settings: TangoGlobalSettings, value: bool) -> TangoGl
     return settings
 
 
-@set.command(**_CLICK_COMMAND_DEFAULTS)
+@set_setting.command(**_CLICK_COMMAND_DEFAULTS)
 @click.argument(
     "start_method",
     type=click.Choice(["fork", "spawn", "forkserver"], case_sensitive=True),
@@ -606,7 +606,7 @@ def multiprocessing_start_method(
     return settings
 
 
-@set.command(**_CLICK_COMMAND_DEFAULTS)
+@set_setting.command(**_CLICK_COMMAND_DEFAULTS)
 @click.argument(
     "key",
     type=str,

--- a/tango/step.py
+++ b/tango/step.py
@@ -375,7 +375,7 @@ class Step(Registrable, Generic[T]):
                 elif isinstance(o, Params):
                     return Params(result, history=o.history)
             elif isinstance(o, Step):
-                return {"type": "ref", "ref": o.unique_id}
+                return {"type": "ref", "ref": o.name}
             else:
                 return deepcopy(o)
 

--- a/tango/step.py
+++ b/tango/step.py
@@ -432,6 +432,14 @@ class Step(Registrable, Generic[T]):
 
         return subclass(step_name=step_name, step_config=raw_step_config, **kwargs)
 
+    # We only want one step object per step with a given unique id.
+    def __copy__(self):
+        return self
+
+    # We only want one step object per step with a given unique id.
+    def __deepcopy__(self, memo=None):
+        return self
+
     @abstractmethod
     def run(self, **kwargs) -> T:
         """


### PR DESCRIPTION
#544 needs to be merged first.

We call `deepcopy()` on params objects, which contain Step objects, to set `raw_config`. That makes a copy of the step object every time it is used. Worse, this happens recursively, so we make a copy of a step object for every downstream step that depends on it directly or indirectly.

This solution replaces `Step` with refs when we're constructing the raw configs.