### PR TITLE
Use commit at time executor is instantiated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- The `BeakerExecutor` now uses the HEAD commit at the time the executor is instantiated to executor a step instead of the HEAD commit at the time the step is run.
+
 ### Fixed
 
 - Removed unnecessary code coverage dev requirements.

--- a/tango/integrations/beaker/executor.py
+++ b/tango/integrations/beaker/executor.py
@@ -473,7 +473,8 @@ class BeakerExecutor(Executor):
                 f"Missing git data. "
                 f"BeakerExecutor requires a git repository with a GitHub remote."
             )
-        self.git = git
+        self._github_account, self._github_repo = self._parse_git_remote(git)
+        self._git_commit = git.commit
 
     def check_repo_state(self):
         if not self.allow_dirty:
@@ -929,14 +930,11 @@ class BeakerExecutor(Executor):
         experiment_name = (
             f"{Constants.STEP_EXPERIMENT_PREFIX}{step.unique_id}-{str(uuid.uuid4())[:8]}"
         )
-
-        # Ensure we're working in a GitHub repository.
-        try:
-            github_account, github_repo = self._parse_git_remote(self.git.remote)
-        except ValueError:
-            raise ExecutorError("BeakerExecutor requires a git repository with a GitHub remote.")
-        git_ref = self.git.commit
-
+        github_account, github_repo, git_ref = (
+            self._github_account,
+            self._github_repo,
+            self._git_commit,
+        )
         if not self._logged_git_info:
             self._logged_git_info = True
             cli_logger.info(

--- a/tango/integrations/beaker/executor.py
+++ b/tango/integrations/beaker/executor.py
@@ -473,7 +473,7 @@ class BeakerExecutor(Executor):
                 f"Missing git data. "
                 f"BeakerExecutor requires a git repository with a GitHub remote."
             )
-        self._github_account, self._github_repo = self._parse_git_remote(git)
+        self._github_account, self._github_repo = self._parse_git_remote(git.remote)
         self._git_commit = git.commit
 
     def check_repo_state(self):


### PR DESCRIPTION
For the `BeakerExecutor`, instead of using the HEAD commit at the time each step is submitted.
